### PR TITLE
ontology docker support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,52 @@ GC=go build
 VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
 BUILD_NODE_PAR = -ldflags "-X github.com/ontio/ontology/common/config.Version=$(VERSION)" #-race
 
-all:
+ARCH=$(shell uname -m)
+DBUILD=docker build
+DRUN=docker run
+DOCKER_NS ?= ontio
+DOCKER_TAG=$(ARCH)-$(VERSION)
+CONFIG_FILES=$(shell ls *.json)
+WALLET_FILE=wallet.dat
+
+all: ontology
+
+ontology:
 	$(GC)  $(BUILD_NODE_PAR) -o ontology main.go
 
 format:
 	$(GOFMT) -w main.go
 
+$(WALLET_FILE): nodectl
+	./nodectl wallet -c -p passwordtest -n $(WALLET_FILE) 
+
+docker/payload: docker/build/bin/ontology docker/Dockerfile $(CONFIG_FILES) $(WALLET_FILE)
+	@echo "Building ontology payload"
+	@mkdir -p $@
+	@cp docker/Dockerfile $@
+	@cp docker/build/bin/ontology $@
+	@tar czf $@/config.tgz $(CONFIG_FILES) $(WALLET_FILE)
+	@touch $@
+
+docker/build/bin/%: Makefile
+	@echo "Building ontology in docker"
+	@mkdir -p docker/build/bin docker/build/pkg
+	@$(DRUN) --rm \
+		-v $(abspath docker/build/bin):/go/bin \
+		-v $(abspath docker/build/pkg):/go/pkg \
+		-v $(GOPATH)/src:/go/src \
+		-w /go/src/github.com/ontio/ontology \
+		golang:1.9.5-stretch \
+		$(GC)  $(BUILD_NODE_PAR) -o docker/build/bin/ontology main.go
+	@touch $@
+
+docker: Makefile docker/payload docker/Dockerfile 
+	@echo "Building ontology docker"
+	@$(DBUILD) -t $(DOCKER_NS)/ontology docker/payload
+	@docker tag $(DOCKER_NS)/ontology $(DOCKER_NS)/ontology:$(DOCKER_TAG)
+	@touch $@
+
 clean:
 	rm -rf *.8 *.o *.out *.6
+	rm -rf ontology nodectl docker/payload docker/build
+

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DBUILD=docker build
 DRUN=docker run
 DOCKER_NS ?= ontio
 DOCKER_TAG=$(ARCH)-$(VERSION)
-CONFIG_FILES=$(shell ls *.json)
+ONT_CFG_IN_DOCKER=config-solo.json
 WALLET_FILE=wallet.dat
 
 all: ontology
@@ -22,12 +22,14 @@ format:
 $(WALLET_FILE): nodectl
 	./nodectl wallet -c -p passwordtest -n $(WALLET_FILE) 
 
-docker/payload: docker/build/bin/ontology docker/Dockerfile $(CONFIG_FILES) $(WALLET_FILE)
+docker/payload: docker/build/bin/ontology docker/Dockerfile $(ONT_CFG_IN_DOCKER) $(WALLET_FILE)
 	@echo "Building ontology payload"
 	@mkdir -p $@
 	@cp docker/Dockerfile $@
 	@cp docker/build/bin/ontology $@
-	@tar czf $@/config.tgz $(CONFIG_FILES) $(WALLET_FILE)
+	@cp -f $(ONT_CFG_IN_DOCKER) $@/config.json
+	@cp -f $(WALLET_FILE) $@
+	@tar czf $@/config.tgz -C $@ config.json $(WALLET_FILE)
 	@touch $@
 
 docker/build/bin/%: Makefile

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ ontology:
 format:
 	$(GOFMT) -w main.go
 
-$(WALLET_FILE): nodectl
-	./nodectl wallet -c -p passwordtest -n $(WALLET_FILE) 
+$(WALLET_FILE):
+	@if [ ! -e $(WALLET_FILE) ]; then $(error Please create wallet file first) ; fi
 
 docker/payload: docker/build/bin/ontology docker/Dockerfile $(ONT_CFG_IN_DOCKER) $(WALLET_FILE)
 	@echo "Building ontology payload"
@@ -52,5 +52,5 @@ docker: Makefile docker/payload docker/Dockerfile
 
 clean:
 	rm -rf *.8 *.o *.out *.6
-	rm -rf ontology nodectl docker/payload docker/build
+	rm -rf ontology docker/payload docker/build
 

--- a/config-solo.json
+++ b/config-solo.json
@@ -6,7 +6,7 @@
       "127.0.0.1:20338"
     ],
     "Bookkeepers": [
-      "021dcb1ae0845b44bbd1ea328bf8245f0386f6611923366f0daa83a97dfd93255c"
+      "1202021c6750d2c5d99813997438cee0740b04a73e42664c444e778e001196eed96c9d"
     ],
     "HttpRestPort": 20334,
     "HttpWsPort":20335,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ ENV ONTOLOGY_PATH /var/ontology
 RUN mkdir -p $ONTOLOGY_PATH
 COPY ontology $ONTOLOGY_PATH
 ADD config.tgz $ONTOLOGY_PATH
+EXPOSE 20334 20335 20336 20337 20338 20339
 WORKDIR $ONTOLOGY_PATH
-CMD ["./ontology","-p","passwordtest"]
+CMD ["/bin/sh", "-c", "echo passwordtest | ./ontology"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+
+FROM tianon/ubuntu-core:14.04
+ENV ONTOLOGY_PATH /var/ontology
+RUN mkdir -p $ONTOLOGY_PATH
+COPY ontology $ONTOLOGY_PATH
+ADD config.tgz $ONTOLOGY_PATH
+WORKDIR $ONTOLOGY_PATH
+CMD ["./ontology","-p","passwordtest"]
+


### PR DESCRIPTION
ontology docker is built in two step:
1. build ontology in docker golang:1.9.5-stretch
2. build ontology docker based on ubuntu-core:14.04

golang:1.9.5-stretch is a minimal go-build-env docker
ubuntu-core:14.04 is a minimal usable host docker.