### PR TITLE
add unit test case of account and common

### DIFF
--- a/account/account_test.go
+++ b/account/account_test.go
@@ -1,0 +1,41 @@
+package account
+
+import (
+	"github.com/ontio/ontology/core/types"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestNewAccount(t *testing.T) {
+	defer func() {
+		os.RemoveAll("Log/")
+	}()
+
+	names := []string{
+		"",
+		"SHA224withECDSA",
+		"SHA256withECDSA",
+		"SHA384withECDSA",
+		"SHA512withECDSA",
+		"SHA3-224withECDSA",
+		"SHA3-256withECDSA",
+		"SHA3-384withECDSA",
+		"SHA3-512withECDSA",
+		"RIPEMD160withECDSA",
+		"SM3withSM2",
+		"SHA512withEdDSA",
+	}
+	accounts := make([]*Account, len(names))
+	for k, v := range names {
+		accounts[k] = NewAccount(v)
+		assert.NotNil(t, accounts[k])
+		assert.NotNil(t, accounts[k].PrivateKey)
+		assert.NotNil(t, accounts[k].PublicKey)
+		assert.NotNil(t, accounts[k].Address)
+		assert.NotNil(t, accounts[k].PrivKey())
+		assert.NotNil(t, accounts[k].PubKey())
+		assert.NotNil(t, accounts[k].Scheme())
+		assert.Equal(t, accounts[k].Address, types.AddressFromPubKey(accounts[k].PublicKey))
+	}
+}

--- a/account/file_store_test.go
+++ b/account/file_store_test.go
@@ -1,0 +1,62 @@
+package account
+
+import (
+	"testing"
+	"encoding/hex"
+	"github.com/ontio/ontology-crypto/keypair"
+	"github.com/ontio/ontology/core/types"
+	"crypto/sha256"
+	"github.com/stretchr/testify/assert"
+	"os"
+)
+
+func genAccountx() (*Accountx, *keypair.ProtectedKey){
+	var acc = new(Accountx)
+	prvkey, pubkey, _ := keypair.GenerateKeyPair(keypair.PK_ECDSA, keypair.P256)
+	ta := types.AddressFromPubKey(pubkey)
+	address := ta.ToBase58()
+	password := []byte("123456")
+	prvSectet, _ := keypair.EncryptPrivateKey(prvkey, address, password)
+	h := sha256.Sum256(password)
+	acc.SetKeyPair(prvSectet)
+	acc.SigSch = "SHA256withECDSA"
+	acc.PubKey = hex.EncodeToString(keypair.SerializePublicKey(pubkey))
+	acc.PassHash = hex.EncodeToString(h[:])
+	return acc, prvSectet
+}
+
+func TestAccountx(t *testing.T) {
+	acc, prvSectet := genAccountx()
+	assert.NotNil(t, acc)
+	assert.Equal(t, acc.Address, acc.ProtectedKey.Address)
+	assert.Equal(t, prvSectet, acc.GetKeyPair())
+	assert.True(t, acc.VerifyPassword([]byte("123456")))
+}
+
+func TestWalletStorage(t *testing.T){
+	defer func() {
+		os.Remove(WALLET_FILENAME)
+		os.RemoveAll("Log/")
+	}()
+
+	wallet := new(WalletData)
+	wallet.Inititalize()
+	wallet.Save(WALLET_FILENAME)
+	walletReadFromFile := new(WalletData)
+	walletReadFromFile.Load(WALLET_FILENAME)
+	assert.Equal(t, walletReadFromFile, wallet)
+	accout, _ := genAccountx()
+	wallet.AddAccount(accout)
+	wallet.AddAccount(accout)
+	wallet.Save(WALLET_FILENAME)
+	walletReadFromFile.Load(WALLET_FILENAME)
+	assert.Equal(t, walletReadFromFile, wallet)
+	wallet.DelAccount(2)
+	assert.Equal(t, 1,len(wallet.Accounts))
+	assert.Panics(t, func(){wallet.DelAccount(2)})
+	wallet.Save(WALLET_FILENAME)
+	walletReadFromFile.Load(WALLET_FILENAME)
+	assert.Equal(t, walletReadFromFile, wallet)
+	defaultAccount := wallet.GetDefaultAccount()
+	assert.Equal(t, defaultAccount, accout)
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexAndBytesTransfer(t *testing.T) {
+	testBytes := []byte("10, 11, 12, 13, 14, 15, 16, 17, 18, 19")
+	stringAfterTrans := ToHexString(testBytes)
+	bytesAfterTrans, err := HexToBytes(stringAfterTrans)
+	assert.Nil(t, err)
+	assert.Equal(t, testBytes, bytesAfterTrans)
+}
+
+func TestGetNonce(t *testing.T) {
+	nonce1 := GetNonce()
+	nonce2 := GetNonce()
+	assert.NotEqual(t, nonce1, nonce2)
+}
+
+func TestFileExisted(t *testing.T) {
+	assert.True(t, FileExisted("common_test.go"))
+	assert.True(t, FileExisted("common.go"))
+	assert.False(t, FileExisted("../log/log.og"))
+	assert.False(t, FileExisted("../log/log.go"))
+	assert.True(t, FileExisted("./log/log.go"))
+}

--- a/common/compact_unit_test.go
+++ b/common/compact_unit_test.go
@@ -1,0 +1,13 @@
+package common
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompactUint(t *testing.T) {
+	a := uint64(1200000)
+	compactValue := SetCompactUint(a)
+	unCompactValue, _ := GetCompactUint(compactValue)
+	assert.Equal(t, unCompactValue, a)
+}

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigGeneration(t *testing.T){
+	polarisConfig := newPolarisConfig()
+	assert.Equal(t, polarisConfig, Parameters)
+	defaultConfig := newDefaultConfig()
+	assert.NotEqual(t, defaultConfig, polarisConfig)
+}

--- a/common/log/log_test.go
+++ b/common/log/log_test.go
@@ -1,0 +1,68 @@
+package log
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func logPrint() {
+	Debug("debug")
+	Info("info")
+	Warn("warn")
+	Error("error")
+	Fatal("fatal")
+	Trace("trace")
+
+	testValue := 1
+	Debugf("debug %v", testValue)
+	Infof("info %v", testValue)
+	Warnf("warn %v", testValue)
+	Errorf("error %v", testValue)
+	Fatalf("fatal %v", testValue)
+	Tracef("trace %v", testValue)
+}
+
+func TestLog(t *testing.T) {
+	defer func() {
+		os.RemoveAll("Log/")
+	}()
+
+	Init(PATH, Stdout)
+	Log.SetDebugLevel(DebugLog)
+	logPrint()
+
+	Log.SetDebugLevel(WarnLog)
+
+	logPrint()
+
+	err := ClosePrintLog()
+	assert.Nil(t, err)
+}
+
+func TestNewLogFile(t *testing.T) {
+	defer func() {
+		os.RemoveAll("Log/")
+	}()
+	Init(PATH, Stdout)
+	logfileNum1, err1 := ioutil.ReadDir("Log/")
+	if err1 != nil {
+		fmt.Println(err1)
+		return
+	}
+	logPrint()
+	isNeedNewFile := CheckIfNeedNewFile()
+	assert.NotEqual(t, isNeedNewFile, true)
+	ClosePrintLog()
+	time.Sleep(time.Second * 2)
+	Init(PATH, Stdout)
+	logfileNum2, err2 := ioutil.ReadDir("Log/")
+	if err2 != nil {
+		fmt.Println(err2)
+		return
+	}
+	assert.Equal(t, len(logfileNum1), (len(logfileNum2) - 1))
+}

--- a/common/password/password_test.go
+++ b/common/password/password_test.go
@@ -1,0 +1,18 @@
+package password
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetAccountPassword(t *testing.T) {
+	var password, err = GetAccountPassword()
+	assert.Nil(t, password)
+	assert.NotNil(t, err)
+	password, err = GetPassword()
+	assert.Nil(t, password)
+	assert.NotNil(t, err)
+	password, err = GetConfirmedPassword()
+	assert.Nil(t, password)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
the compact_uint_test test error, because of  the index out of range. See the $GOROOT/src/encoding/binary/binary.go, line 76 (bounds check hint to compiler; see golang.org/issue/14808).