### PR TITLE
Bypass vbft msg and  Remove peer which have error occur in connecting state.

### DIFF
--- a/p2pserver/actor/req/consensus.go
+++ b/p2pserver/actor/req/consensus.go
@@ -19,8 +19,11 @@
 package req
 
 import (
+	"strings"
+
 	"github.com/ontio/ontology-crypto/keypair"
 	"github.com/ontio/ontology-eventbus/actor"
+	"github.com/ontio/ontology/common/config"
 	msgTypes "github.com/ontio/ontology/p2pserver/message/types"
 )
 
@@ -31,6 +34,11 @@ func SetConsensusPid(conPid *actor.PID) {
 }
 
 func NotifyPeerState(peer keypair.PublicKey, connected bool) error {
+	consensusType := strings.ToLower(config.Parameters.ConsensusType)
+	if consensusType != "vbft" {
+		return nil
+	}
+
 	if ConsensusPid != nil {
 		ConsensusPid.Tell(&msgTypes.PeerStateUpdate{
 			PeerPubKey: peer,

--- a/p2pserver/actor/req/consensus.go
+++ b/p2pserver/actor/req/consensus.go
@@ -19,8 +19,6 @@
 package req
 
 import (
-	"strings"
-
 	"github.com/ontio/ontology-crypto/keypair"
 	"github.com/ontio/ontology-eventbus/actor"
 	"github.com/ontio/ontology/common/config"
@@ -34,8 +32,7 @@ func SetConsensusPid(conPid *actor.PID) {
 }
 
 func NotifyPeerState(peer keypair.PublicKey, connected bool) error {
-	consensusType := strings.ToLower(config.Parameters.ConsensusType)
-	if consensusType != "vbft" {
+	if config.DefConfig.Genesis.ConsensusType != config.CONSENSUS_TYPE_VBFT {
 		return nil
 	}
 

--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -241,25 +241,27 @@ func VersionHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, a
 		return err
 	}
 
+	remotePeer := p2p.GetPeerFromAddr(data.Addr)
+	if remotePeer == nil {
+		log.Warn(" peer is not exist", data.Addr)
+		//peer not exist,just remove list and return
+		p2p.RemoveFromConnectingList(data.Addr)
+		return errors.New("peer is not exist ")
+	}
+
 	if version.P.IsConsensus == true {
 		if config.DefConfig.P2PNode.DualPortSupport == false {
 			log.Warn("consensus port not surpport")
-			p2p.RemoveFromConnectingList(data.Addr)
+			remotePeer.CloseCons()
 			return errors.New("consensus port not surpport")
 		}
-		remotePeer := p2p.GetPeerFromAddr(data.Addr)
 
-		if remotePeer == nil {
-			log.Warn(" peer is not exist", data.Addr)
-			p2p.RemoveFromConnectingList(data.Addr)
-			return errors.New("peer is not exist ")
-		}
 		p := p2p.GetPeer(version.P.Nonce)
 
 		if p == nil {
 			log.Warn("sync link is not exist", version.P.Nonce)
-			p2p.RemovePeerConsAddress(data.Addr)
-			p2p.RemoveFromConnectingList(data.Addr)
+			remotePeer.CloseCons()
+			remotePeer.CloseSync()
 			return errors.New("sync link is not exist")
 		} else {
 			//p synclink must exist,merged
@@ -272,15 +274,13 @@ func VersionHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, a
 		if version.P.Nonce == p2p.GetID() {
 			log.Warn("The node handshake with itself")
 			remotePeer.CloseCons()
-			p2p.RemovePeerConsAddress(data.Addr)
-			p2p.RemoveFromConnectingList(data.Addr)
 			return errors.New("The node handshake with itself ")
 		}
 
 		s := remotePeer.GetConsState()
 		if s != msgCommon.INIT && s != msgCommon.HAND {
 			log.Warn("Unknown status to received version", s)
-			p2p.RemoveFromConnectingList(data.Addr)
+			remotePeer.CloseCons()
 			return errors.New("Unknown status to received version ")
 		}
 
@@ -302,26 +302,17 @@ func VersionHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, a
 		p2p.Send(remotePeer, buf, true)
 		return nil
 	} else {
-		remotePeer := p2p.GetPeerFromAddr(data.Addr)
 
-		if remotePeer == nil {
-			log.Warn("peer is not exist", data.Addr)
-			p2p.RemovePeerSyncAddress(data.Addr)
-			p2p.RemoveFromConnectingList(data.Addr)
-			return errors.New("peer is not exist ")
-		}
 		if version.P.Nonce == p2p.GetID() {
 			log.Warn("The node handshake with itself")
 			remotePeer.CloseSync()
-			p2p.RemovePeerSyncAddress(data.Addr)
-			p2p.RemoveFromConnectingList(data.Addr)
 			return errors.New("The node handshake with itself ")
 		}
 
 		s := remotePeer.GetSyncState()
 		if s != msgCommon.INIT && s != msgCommon.HAND {
 			log.Warn("Unknown status to received version", s)
-			p2p.RemoveFromConnectingList(data.Addr)
+			remotePeer.CloseSync()
 			return errors.New("Unknown status to received version")
 		}
 
@@ -332,9 +323,6 @@ func VersionHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, a
 			// Close the connection and release the node source
 			n.CloseSync()
 			n.CloseCons()
-			p2p.RemovePeerSyncAddress(n.GetAddr())
-			p2p.RemovePeerConsAddress(n.GetAddr())
-			p2p.RemoveFromConnectingList(data.Addr)
 			if pid != nil {
 				input := &msgCommon.RemovePeerID{
 					ID: version.P.Nonce,
@@ -617,14 +605,15 @@ func DisconnectHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID
 	}
 
 	p2p.RemoveFromConnectingList(data.Addr)
-	p2p.RemovePeerSyncAddress(data.Addr)
-	p2p.RemovePeerConsAddress(data.Addr)
 
 	if remotePeer.SyncLink.GetAddr() == data.Addr {
+		p2p.RemovePeerSyncAddress(data.Addr)
+		p2p.RemovePeerConsAddress(data.Addr)
 		remotePeer.CloseSync()
 		remotePeer.CloseCons()
 	}
 	if remotePeer.ConsLink.GetAddr() == data.Addr {
+		p2p.RemovePeerConsAddress(data.Addr)
 		remotePeer.CloseCons()
 	}
 	return nil

--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -428,7 +428,7 @@ func VerAckHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 
 		} else {
 			//consensus port connect
-			if config.DefConfig.P2PNode.DualPortSupport {
+			if config.DefConfig.P2PNode.DualPortSupport && remotePeer.GetConsPort() > 0 {
 				i := strings.Index(addr, ":")
 				if i < 0 {
 					log.Warn("Split IP address error", addr)
@@ -438,9 +438,7 @@ func VerAckHandle(data *msgCommon.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 					strconv.Itoa(int(remotePeer.GetConsPort()))
 				go p2p.Connect(nodeConsensusAddr, true)
 			}
-
 		}
-
 		buf, _ := msgpack.NewAddrReq()
 		go p2p.Send(remotePeer, buf, false)
 

--- a/p2pserver/net/netserver/netserver.go
+++ b/p2pserver/net/netserver/netserver.go
@@ -88,13 +88,23 @@ func (this *NetServer) init(pubKey keypair.PublicKey) error {
 		this.base.SetServices(uint64(common.SERVICE_NODE))
 	}
 
-	if config.DefConfig.P2PNode.NodeConsensusPort == 0 || config.DefConfig.P2PNode.NodePort == 0 ||
-		config.DefConfig.P2PNode.NodeConsensusPort == config.DefConfig.P2PNode.NodePort {
-		log.Error("Network port invalid, please check config.json")
-		return errors.New("Invalid port")
+	if config.DefConfig.P2PNode.NodePort == 0 {
+		log.Error("link port invalid")
+		return errors.New("invalid link port")
 	}
+
 	this.base.SetSyncPort(uint16(config.DefConfig.P2PNode.NodePort))
-	this.base.SetConsPort(uint16(config.DefConfig.P2PNode.NodeConsensusPort))
+
+	if config.DefConfig.P2PNode.DualPortSupport {
+		if config.DefConfig.P2PNode.NodeConsensusPort == 0 {
+			log.Error("consensus port invalid")
+			return errors.New("invalid consensus port")
+		}
+
+		this.base.SetConsPort(uint16(config.DefConfig.P2PNode.NodeConsensusPort))
+	} else {
+		this.base.SetConsPort(0)
+	}
 
 	this.base.SetRelay(true)
 


### PR DESCRIPTION
Bypass vbft msg actor under other consensus algo
Remove peer which have error occur in connecting state.

Signed-off-by: Xiang Fu <fuxiang@onchain.com>