### PR TITLE
ONT-551 add export account

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -72,6 +72,8 @@ type Client interface {
 	ChangePassword(address string, oldPasswd, newPasswd []byte) error
 	//Change sig scheme to account
 	ChangeSigScheme(address string, sigScheme s.SignatureScheme, passwd []byte) error
+	//Get the underlying wallet data
+	GetWalletData() *WalletData
 }
 
 func Open(path string) (Client, error) {
@@ -313,7 +315,9 @@ func (this *ClientImpl) getAccount(accData *AccountData, passwd []byte) (*Accoun
 	if !accData.VerifyPassword(passwd) {
 		return nil, fmt.Errorf("verify password failed")
 	}
+	keypair.SetScryptParam(this.walletData.Scrypt)
 	privateKey, err := keypair.DecryptPrivateKey(&accData.ProtectedKey, passwd)
+	keypair.SetScryptParam(nil)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt PrivateKey error:%s", err)
 	}
@@ -582,4 +586,8 @@ func (this *ClientImpl) checkSigScheme(keyType, sigScheme string) bool {
 		return false
 	}
 	return true
+}
+
+func (this *ClientImpl) GetWalletData() *WalletData {
+	return this.walletData
 }

--- a/account/file_store.go
+++ b/account/file_store.go
@@ -24,12 +24,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	"github.com/ontio/ontology-crypto/keypair"
-	//"github.com/ontio/ontology/core/types"
 	"io/ioutil"
 	"os"
 
+	"github.com/ontio/ontology-crypto/keypair"
 	"github.com/ontio/ontology/common"
 )
 

--- a/account/file_store.go
+++ b/account/file_store.go
@@ -22,11 +22,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+
 	"github.com/ontio/ontology-crypto/keypair"
 	//"github.com/ontio/ontology/core/types"
-	"github.com/ontio/ontology/common"
 	"io/ioutil"
 	"os"
+
+	"github.com/ontio/ontology/common"
 )
 
 /** AccountData - for wallet read and save, no crypto object included **/
@@ -91,6 +95,23 @@ func NewWalletData() *WalletData {
 	}
 }
 
+func (this *WalletData) Dump() *WalletData {
+	w := WalletData{}
+	w.Name = this.Name
+	w.Version = this.Version
+	sp := *this.Scrypt
+	w.Scrypt = &sp
+	w.Accounts = make([]*AccountData, len(this.Accounts))
+	for i, v := range this.Accounts {
+		ac := *v
+		ac.SetKeyPair(v.GetKeyPair())
+		w.Accounts[i] = &ac
+	}
+	w.Identities = this.Identities
+	w.Extra = this.Extra
+	return &w
+}
+
 func (this *WalletData) AddAccount(acc *AccountData) {
 	this.Accounts = append(this.Accounts, acc)
 }
@@ -149,6 +170,49 @@ func (this *WalletData) Load(path string) error {
 		return err
 	}
 	return json.Unmarshal(msh, this)
+}
+
+var lowSecurityParam = keypair.ScryptParam{
+	N:     4096,
+	R:     8,
+	P:     8,
+	DKLen: 64,
+}
+
+func (this *WalletData) ToLowSecurity(passwords [][]byte) error {
+	return this.reencrypt(passwords, &lowSecurityParam)
+}
+
+func (this *WalletData) ToDefaultSecurity(passwords [][]byte) error {
+	return this.reencrypt(passwords, nil)
+}
+
+func (this *WalletData) reencrypt(passwords [][]byte, param *keypair.ScryptParam) error {
+	if len(passwords) != len(this.Accounts) {
+		return errors.New("not enough passwords for the accounts")
+	}
+	keys := make([]*keypair.ProtectedKey, len(this.Accounts))
+	for i, v := range this.Accounts {
+		if !v.VerifyPassword(passwords[i]) {
+			return fmt.Errorf("incorrect password of account %d", i+1)
+		}
+		prot, err := keypair.ReencryptPrivateKey(&v.ProtectedKey, passwords[i], passwords[i], this.Scrypt, param)
+		if err != nil {
+			return fmt.Errorf("re-encrypt account %d failed: %s", i, err)
+		}
+		keys[i] = prot
+	}
+
+	for i, v := range keys {
+		this.Accounts[i].SetKeyPair(v)
+	}
+	if param != nil {
+		this.Scrypt = param
+	} else {
+		// default parameters
+		this.Scrypt = keypair.GetScryptParameters()
+	}
+	return nil
 }
 
 //TODO:: determine identity structure

--- a/cmd/account_cmd.go
+++ b/cmd/account_cmd.go
@@ -464,6 +464,9 @@ func accountExport(ctx *cli.Context) error {
 		}
 		wallet = wallet.Dump()
 		err := wallet.ToLowSecurity(passwords)
+		for _, v := range passwords {
+			common.ClearPasswd(v)
+		}
 		if err != nil {
 			return fmt.Errorf("export failed: %s", err)
 		}

--- a/cmd/account_cmd.go
+++ b/cmd/account_cmd.go
@@ -22,6 +22,8 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
+	"os"
+
 	"github.com/ontio/ontology-crypto/keypair"
 	"github.com/ontio/ontology-crypto/signature"
 	"github.com/ontio/ontology/account"
@@ -29,7 +31,6 @@ import (
 	"github.com/ontio/ontology/cmd/utils"
 	"github.com/ontio/ontology/common/password"
 	"github.com/urfave/cli"
-	"os"
 )
 
 var (
@@ -54,10 +55,10 @@ var (
 					utils.AccountLabelFlag,
 					utils.WalletFileFlag,
 				},
-				Description: ` Add a new account to wallet. 
+				Description: ` Add a new account to wallet.
    Ontology support three type of key: ecdsa, sm2 and ed25519, and support 224、256、384、521 bits length of key in ecdsa, but only support 256 bits length of key in sm2 and ed25519.
-   Ontology support multiple signature scheme. 
-   For ECDSA support SHA224withECDSA、SHA256withECDSA、SHA384withECDSA、SHA512withEdDSA、SHA3-224withECDSA、SHA3-256withECDSA、SHA3-384withECDSA、SHA3-512withECDSA、RIPEMD160withECDSA; 
+   Ontology support multiple signature scheme.
+   For ECDSA support SHA224withECDSA、SHA256withECDSA、SHA384withECDSA、SHA512withEdDSA、SHA3-224withECDSA、SHA3-256withECDSA、SHA3-384withECDSA、SHA3-512withECDSA、RIPEMD160withECDSA;
    For SM2 support SM3withSM2, and for SHA512withEdDSA.
    -------------------------------------------------
       Key   |key-length(bits)|  signature-scheme
@@ -130,6 +131,16 @@ var (
 					utils.AccountSourceFileFlag,
 				},
 				Description: "Import accounts of wallet to another. If not specific accounts in args, all account in source will be import",
+			},
+			{
+				Action:    accountExport,
+				Name:      "export",
+				Usage:     "Export accounts to a specified wallet file",
+				ArgsUsage: "[sub-command options] <filename>",
+				Flags: []cli.Flag{
+					utils.WalletFileFlag,
+					utils.AccountLowSecurityFlag,
+				},
 			},
 		},
 	}
@@ -422,5 +433,45 @@ func accountImport(ctx *cli.Context) error {
 		fmt.Printf("Import account:%s label:%s successfully.\n", accMeta.Address, accMeta.Label)
 	}
 	fmt.Printf("\nImport wallet:%s to %s complete, total:%d success:%d failed:%d skip:%d\n", source, target, total, succ, fail, skip)
+	return nil
+}
+
+func accountExport(ctx *cli.Context) error {
+	if ctx.NArg() <= 0 {
+		return fmt.Errorf("Missing target file name")
+	}
+	target := ctx.Args().First()
+	client, err := common.OpenWallet(ctx)
+	if err != nil {
+		return err
+	}
+	wallet := client.GetWalletData()
+	if ctx.IsSet(utils.GetFlagName(utils.AccountLowSecurityFlag)) {
+		n := client.GetAccountNum()
+		passwords := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			ac := client.GetAccountMetadataByIndex(i + 1)
+			fmt.Printf("Account %d %s: %s", i+1, ac.Label, ac.Address)
+			for j := 0; j < 3; j++ {
+				pwd, err := password.GetPassword()
+				if err != nil {
+					fmt.Println(err)
+				} else {
+					passwords[i] = pwd
+					break
+				}
+			}
+		}
+		wallet = wallet.Dump()
+		err := wallet.ToLowSecurity(passwords)
+		if err != nil {
+			return fmt.Errorf("export failed: %s", err)
+		}
+	}
+	err = wallet.Save(target)
+	if err != nil {
+		return fmt.Errorf("save wallet file error: %s", err)
+	}
+
 	return nil
 }

--- a/cmd/usage.go
+++ b/cmd/usage.go
@@ -96,6 +96,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.AccountQuantityFlag,
 			utils.AccountChangePasswdFlag,
 			utils.AccountSourceFileFlag,
+			utils.AccountLowSecurityFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -191,6 +191,10 @@ var (
 		Name:  "changepasswd",
 		Usage: "Change account password",
 	}
+	AccountLowSecurityFlag = cli.BoolFlag{
+		Name:  "low-security",
+		Usage: "Change account to low protection strength for low performance devices",
+	}
 
 	//SmartContract setting
 	ContractAddrFlag = cli.StringFlag{


### PR DESCRIPTION
Export accounts to another wallet file. Support re-encryption for lower performance devices.