### PR TITLE
ONT-604 refactor the auth contract

### DIFF
--- a/smartcontract/service/native/auth/param.go
+++ b/smartcontract/service/native/auth/param.go
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/ontio/ontology/common/serialization"
+)
+
+/* **********************************************   */
+type InitContractAdminParam struct {
+	AdminOntID []byte
+}
+
+func (this *InitContractAdminParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.AdminOntID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *InitContractAdminParam) Deserialize(rd io.Reader) error {
+	var err error
+	if this.AdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	return nil
+}
+
+/* **********************************************   */
+type TransferParam struct {
+	ContractAddr  []byte
+	NewAdminOntID []byte
+	KeyNo         uint32
+}
+
+func (this *TransferParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.NewAdminOntID); err != nil {
+		return err
+	}
+	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func (this *TransferParam) Deserialize(rd io.Reader) error {
+	var err error
+	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.NewAdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	return nil
+}
+
+/* **********************************************   */
+type FuncsToRoleParam struct {
+	ContractAddr []byte
+	AdminOntID   []byte
+	Role         []byte
+	FuncNames    []string
+	KeyNo        uint32
+}
+
+func (this *FuncsToRoleParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.AdminOntID); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarUint(w, uint64(len(this.FuncNames))); err != nil {
+		return err
+	}
+	for _, fn := range this.FuncNames {
+		if err := serialization.WriteString(w, fn); err != nil {
+			return err
+		}
+	}
+	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func (this *FuncsToRoleParam) Deserialize(rd io.Reader) error {
+	var err error
+	var fnLen uint64
+	var i uint64
+
+	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.AdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if fnLen, err = serialization.ReadVarUint(rd, 0); err != nil {
+		return err
+	}
+	this.FuncNames = make([]string, fnLen)
+	for i = 0; i < fnLen; i++ {
+		fn, err := serialization.ReadString(rd)
+		if err != nil {
+			return err
+		}
+		this.FuncNames[i] = fn
+	}
+	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	return nil
+}
+
+type OntIDsToRoleParam struct {
+	ContractAddr []byte
+	AdminOntID   []byte
+	Role         []byte
+	Persons      [][]byte
+	KeyNo        uint32
+}
+
+func (this *OntIDsToRoleParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.AdminOntID); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarUint(w, uint64(len(this.Persons))); err != nil {
+		return err
+	}
+	for _, p := range this.Persons {
+		if err := serialization.WriteVarBytes(w, p); err != nil {
+			return err
+		}
+	}
+	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func (this *OntIDsToRoleParam) Deserialize(rd io.Reader) error {
+	var err error
+	var pLen uint64
+	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.AdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if pLen, err = serialization.ReadVarUint(rd, 0); err != nil {
+		return err
+	}
+	this.Persons = make([][]byte, pLen)
+	for i := uint64(0); i < pLen; i++ {
+		p, err := serialization.ReadVarBytes(rd)
+		if err != nil {
+			return err
+		}
+		this.Persons[i] = p
+	}
+	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	return nil
+}
+
+type DelegateParam struct {
+	ContractAddr []byte
+	From         []byte
+	To           []byte
+	Role         []byte
+	Period       uint32
+	Level        uint
+	KeyNo        uint32
+}
+
+func (this *DelegateParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.From); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.To); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
+		return err
+	}
+	if err := serialization.WriteUint32(w, this.Period); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarUint(w, uint64(this.Level)); err != nil {
+		return err
+	}
+	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *DelegateParam) Deserialize(rd io.Reader) error {
+	var err error
+	var period uint32
+	var level uint64
+	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.From, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.To, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Period, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	if level, err = serialization.ReadVarUint(rd, 0); err != nil {
+		return err
+	}
+	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	if level > math.MaxInt8 {
+		return fmt.Errorf("period or level too large: (%d, %d)", period, level)
+	}
+	this.Level = uint(level)
+	return nil
+}
+
+type WithdrawParam struct {
+	ContractAddr []byte
+	Initiator    []byte
+	Delegate     []byte
+	Role         []byte
+	KeyNo        uint32
+}
+
+func (this *WithdrawParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Initiator); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Delegate); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
+		return err
+	}
+	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+		return err
+	}
+	return nil
+}
+func (this *WithdrawParam) Deserialize(rd io.Reader) error {
+	var err error
+	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Initiator, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Delegate, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	return nil
+}
+
+type VerifyTokenParam struct {
+	ContractAddr []byte
+	Caller       []byte
+	Fn           []byte
+	KeyNo        uint32
+}
+
+func (this *VerifyTokenParam) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Caller); err != nil {
+		return err
+	}
+	if err := serialization.WriteVarBytes(w, this.Fn); err != nil {
+		return err
+	}
+	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *VerifyTokenParam) Deserialize(rd io.Reader) error {
+	var err error
+	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.Caller, err = serialization.ReadVarBytes(rd); err != nil {
+		return err //deserialize caller error
+	}
+	if this.Fn, err = serialization.ReadVarBytes(rd); err != nil {
+		return err
+	}
+	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+		return err
+	}
+	return nil
+}

--- a/smartcontract/service/native/auth/param.go
+++ b/smartcontract/service/native/auth/param.go
@@ -50,7 +50,7 @@ func (this *InitContractAdminParam) Deserialize(rd io.Reader) error {
 type TransferParam struct {
 	ContractAddr  []byte
 	NewAdminOntID []byte
-	KeyNo         uint32
+	KeyNo         uint64
 }
 
 func (this *TransferParam) Serialize(w io.Writer) error {
@@ -60,7 +60,7 @@ func (this *TransferParam) Serialize(w io.Writer) error {
 	if err := serialization.WriteVarBytes(w, this.NewAdminOntID); err != nil {
 		return err
 	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+	if err := serialization.WriteVarUint(w, this.KeyNo); err != nil {
 		return nil
 	}
 	return nil
@@ -74,7 +74,7 @@ func (this *TransferParam) Deserialize(rd io.Reader) error {
 	if this.NewAdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
 		return err
 	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+	if this.KeyNo, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
 	return nil
@@ -86,7 +86,7 @@ type FuncsToRoleParam struct {
 	AdminOntID   []byte
 	Role         []byte
 	FuncNames    []string
-	KeyNo        uint32
+	KeyNo        uint64
 }
 
 func (this *FuncsToRoleParam) Serialize(w io.Writer) error {
@@ -107,7 +107,7 @@ func (this *FuncsToRoleParam) Serialize(w io.Writer) error {
 			return err
 		}
 	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+	if err := serialization.WriteVarUint(w, this.KeyNo); err != nil {
 		return nil
 	}
 	return nil
@@ -130,15 +130,15 @@ func (this *FuncsToRoleParam) Deserialize(rd io.Reader) error {
 	if fnLen, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
-	this.FuncNames = make([]string, fnLen)
+	this.FuncNames = make([]string, 0)
 	for i = 0; i < fnLen; i++ {
 		fn, err := serialization.ReadString(rd)
 		if err != nil {
 			return err
 		}
-		this.FuncNames[i] = fn
+		this.FuncNames = append(this.FuncNames, fn)
 	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+	if this.KeyNo, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
 	return nil
@@ -149,7 +149,7 @@ type OntIDsToRoleParam struct {
 	AdminOntID   []byte
 	Role         []byte
 	Persons      [][]byte
-	KeyNo        uint32
+	KeyNo        uint64
 }
 
 func (this *OntIDsToRoleParam) Serialize(w io.Writer) error {
@@ -170,7 +170,7 @@ func (this *OntIDsToRoleParam) Serialize(w io.Writer) error {
 			return err
 		}
 	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+	if err := serialization.WriteVarUint(w, this.KeyNo); err != nil {
 		return nil
 	}
 	return nil
@@ -191,15 +191,15 @@ func (this *OntIDsToRoleParam) Deserialize(rd io.Reader) error {
 	if pLen, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
-	this.Persons = make([][]byte, pLen)
+	this.Persons = make([][]byte, 0)
 	for i := uint64(0); i < pLen; i++ {
 		p, err := serialization.ReadVarBytes(rd)
 		if err != nil {
 			return err
 		}
-		this.Persons[i] = p
+		this.Persons = append(this.Persons, p)
 	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+	if this.KeyNo, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
 	return nil
@@ -210,9 +210,9 @@ type DelegateParam struct {
 	From         []byte
 	To           []byte
 	Role         []byte
-	Period       uint32
-	Level        uint
-	KeyNo        uint32
+	Period       uint64
+	Level        uint64
+	KeyNo        uint64
 }
 
 func (this *DelegateParam) Serialize(w io.Writer) error {
@@ -228,13 +228,13 @@ func (this *DelegateParam) Serialize(w io.Writer) error {
 	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
 		return err
 	}
-	if err := serialization.WriteUint32(w, this.Period); err != nil {
+	if err := serialization.WriteVarUint(w, this.Period); err != nil {
 		return err
 	}
 	if err := serialization.WriteVarUint(w, uint64(this.Level)); err != nil {
 		return err
 	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+	if err := serialization.WriteVarUint(w, this.KeyNo); err != nil {
 		return err
 	}
 	return nil
@@ -242,7 +242,6 @@ func (this *DelegateParam) Serialize(w io.Writer) error {
 
 func (this *DelegateParam) Deserialize(rd io.Reader) error {
 	var err error
-	var period uint32
 	var level uint64
 	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
 		return err
@@ -256,19 +255,19 @@ func (this *DelegateParam) Deserialize(rd io.Reader) error {
 	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
 		return err
 	}
-	if this.Period, err = serialization.ReadUint32(rd); err != nil {
+	if this.Period, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
 	if level, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+	if this.KeyNo, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
-	if level > math.MaxInt8 {
-		return fmt.Errorf("period or level too large: (%d, %d)", period, level)
+	if level > math.MaxInt8 || this.Period > math.MaxUint32 {
+		return fmt.Errorf("period or level too large: (%d, %d)", this.Period, level)
 	}
-	this.Level = uint(level)
+	this.Level = level
 	return nil
 }
 
@@ -277,7 +276,7 @@ type WithdrawParam struct {
 	Initiator    []byte
 	Delegate     []byte
 	Role         []byte
-	KeyNo        uint32
+	KeyNo        uint64
 }
 
 func (this *WithdrawParam) Serialize(w io.Writer) error {
@@ -293,7 +292,7 @@ func (this *WithdrawParam) Serialize(w io.Writer) error {
 	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
 		return err
 	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+	if err := serialization.WriteVarUint(w, this.KeyNo); err != nil {
 		return err
 	}
 	return nil
@@ -312,7 +311,7 @@ func (this *WithdrawParam) Deserialize(rd io.Reader) error {
 	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
 		return err
 	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+	if this.KeyNo, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
 	return nil
@@ -322,7 +321,7 @@ type VerifyTokenParam struct {
 	ContractAddr []byte
 	Caller       []byte
 	Fn           []byte
-	KeyNo        uint32
+	KeyNo        uint64
 }
 
 func (this *VerifyTokenParam) Serialize(w io.Writer) error {
@@ -335,7 +334,7 @@ func (this *VerifyTokenParam) Serialize(w io.Writer) error {
 	if err := serialization.WriteVarBytes(w, this.Fn); err != nil {
 		return err
 	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
+	if err := serialization.WriteVarUint(w, this.KeyNo); err != nil {
 		return err
 	}
 	return nil
@@ -352,7 +351,7 @@ func (this *VerifyTokenParam) Deserialize(rd io.Reader) error {
 	if this.Fn, err = serialization.ReadVarBytes(rd); err != nil {
 		return err
 	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
+	if this.KeyNo, err = serialization.ReadVarUint(rd, 0); err != nil {
 		return err
 	}
 	return nil

--- a/smartcontract/service/native/auth/param_test.go
+++ b/smartcontract/service/native/auth/param_test.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package auth
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+var (
+	admin    []byte
+	newAdmin []byte
+	p1       []byte
+	p2       []byte
+)
+var (
+	funcs           = []string{"foo1", "foo2"}
+	role            = "role"
+	OntContractAddr = []byte{0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
+)
+
+func init() {
+	admin = make([]byte, 32)
+	newAdmin = make([]byte, 32)
+	p1 = make([]byte, 20)
+	p2 = make([]byte, 20)
+	rand.Read(admin)
+	rand.Read(newAdmin)
+	rand.Read(p1)
+	rand.Read(p2)
+}
+func TestSerialization_Init(t *testing.T) {
+	param := &InitContractAdminParam{
+		AdminOntID: admin,
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+
+	param2 := new(InitContractAdminParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(param.AdminOntID, param2.AdminOntID) != 0 {
+		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_Transfer(t *testing.T) {
+	param := &TransferParam{
+		ContractAddr:  OntContractAddr,
+		NewAdminOntID: newAdmin,
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+
+	param2 := new(TransferParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
+		bytes.Compare(param.NewAdminOntID, param2.NewAdminOntID) != 0 {
+		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_AssignFuncs(t *testing.T) {
+	param := &FuncsToRoleParam{
+		ContractAddr: OntContractAddr,
+		AdminOntID:   admin,
+		Role:         []byte("role"),
+		FuncNames:    funcs,
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+
+	param2 := new(FuncsToRoleParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
+		bytes.Compare(param.AdminOntID, param2.AdminOntID) != 0 ||
+		bytes.Compare(param.Role, param2.Role) != 0 {
+		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_AssignOntIDs(t *testing.T) {
+	param := &OntIDsToRoleParam{
+		ContractAddr: OntContractAddr,
+		AdminOntID:   admin,
+		Role:         []byte(role),
+		Persons:      [][]byte{[]byte{0x03, 0x04, 0x05, 0x06}, []byte{0x07, 0x08, 0x09, 0x0a}},
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+	param2 := new(OntIDsToRoleParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
+		bytes.Compare(param.AdminOntID, param2.AdminOntID) != 0 ||
+		bytes.Compare(param.Role, param2.Role) != 0 {
+		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_Delegate(t *testing.T) {
+	param := &DelegateParam{
+		ContractAddr: OntContractAddr,
+		From:         p1,
+		To:           p2,
+		Role:         []byte(role),
+		Period:       60 * 60 * 24,
+		Level:        3,
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+	param2 := new(DelegateParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
+		bytes.Compare(param.From, param2.From) != 0 ||
+		bytes.Compare(param.To, param2.To) != 0 ||
+		bytes.Compare(param.Role, param2.Role) != 0 ||
+		param.Period != param2.Period || param.Level != param2.Level {
+		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_Withdraw(t *testing.T) {
+	param := &WithdrawParam{
+		ContractAddr: OntContractAddr,
+		Initiator:    p1,
+		Delegate:     p2,
+		Role:         []byte(role),
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+	param2 := new(WithdrawParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
+		bytes.Compare(param.Initiator, param2.Initiator) != 0 ||
+		bytes.Compare(param.Delegate, param2.Delegate) != 0 ||
+		bytes.Compare(param.Role, param2.Role) != 0 {
+		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_VerifyToken(t *testing.T) {
+	param := &VerifyTokenParam{
+		ContractAddr: OntContractAddr,
+		Caller:       p1,
+		Fn:           []byte("foo1"),
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+	param2 := new(VerifyTokenParam)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
+		bytes.Compare(param.Caller, param2.Caller) != 0 ||
+		bytes.Compare(param.Fn, param2.Fn) != 0 {
+		t.Fatalf("failed")
+	}
+}

--- a/smartcontract/service/native/auth/state.go
+++ b/smartcontract/service/native/auth/state.go
@@ -49,12 +49,13 @@ func (this *roleFuncs) Deserialize(rd io.Reader) error {
 	if err != nil {
 		return err
 	}
-	this.funcNames = make([]string, fnLen)
+	this.funcNames = make([]string, 0)
 	for i := uint32(0); i < fnLen; i++ {
-		this.funcNames[i], err = serialization.ReadString(rd)
+		fn, err := serialization.ReadString(rd)
 		if err != nil {
 			return err
 		}
+		this.funcNames = append(this.funcNames, fn)
 	}
 	return nil
 }
@@ -142,13 +143,14 @@ func (this *Status) Deserialize(rd io.Reader) error {
 	if err != nil {
 		return err
 	}
-	this.status = make([]*DelegateStatus, sLen)
+	this.status = make([]*DelegateStatus, 0)
 	for i := uint32(0); i < sLen; i++ {
-		this.status[i] = new(DelegateStatus)
-		err = this.status[i].Deserialize(rd)
+		s := new(DelegateStatus)
+		err = s.Deserialize(rd)
 		if err != nil {
 			return err
 		}
+		this.status = append(this.status, s)
 	}
 	return nil
 }
@@ -174,13 +176,14 @@ func (this *roleTokens) Deserialize(rd io.Reader) error {
 	if err != nil {
 		return err
 	}
-	this.tokens = make([]*AuthToken, tLen)
+	this.tokens = make([]*AuthToken, 0)
 	for i := uint32(0); i < tLen; i++ {
-		this.tokens[i] = new(AuthToken)
-		err = this.tokens[i].Deserialize(rd)
+		tok := new(AuthToken)
+		err = tok.Deserialize(rd)
 		if err != nil {
 			return err
 		}
+		this.tokens = append(this.tokens, tok)
 	}
 	return nil
 }

--- a/smartcontract/service/native/auth/state.go
+++ b/smartcontract/service/native/auth/state.go
@@ -45,7 +45,6 @@ func (this *roleFuncs) Serialize(w io.Writer) error {
 
 func (this *roleFuncs) Deserialize(rd io.Reader) error {
 	var err error
-
 	fnLen, err := serialization.ReadUint32(rd)
 	if err != nil {
 		return err

--- a/smartcontract/service/native/auth/state.go
+++ b/smartcontract/service/native/auth/state.go
@@ -19,344 +19,10 @@
 package auth
 
 import (
-	"fmt"
 	"io"
-	"math"
 
 	"github.com/ontio/ontology/common/serialization"
 )
-
-/* **********************************************   */
-type InitContractAdminParam struct {
-	AdminOntID []byte
-}
-
-func (this *InitContractAdminParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.AdminOntID); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (this *InitContractAdminParam) Deserialize(rd io.Reader) error {
-	var err error
-	if this.AdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	return nil
-}
-
-/* **********************************************   */
-type TransferParam struct {
-	ContractAddr  []byte
-	NewAdminOntID []byte
-	KeyNo         uint32
-}
-
-func (this *TransferParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.NewAdminOntID); err != nil {
-		return err
-	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
-		return nil
-	}
-	return nil
-}
-
-func (this *TransferParam) Deserialize(rd io.Reader) error {
-	var err error
-	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.NewAdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	return nil
-}
-
-/* **********************************************   */
-type FuncsToRoleParam struct {
-	ContractAddr []byte
-	AdminOntID   []byte
-	Role         []byte
-	FuncNames    []string
-	KeyNo        uint32
-}
-
-func (this *FuncsToRoleParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.AdminOntID); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarUint(w, uint64(len(this.FuncNames))); err != nil {
-		return err
-	}
-	for _, fn := range this.FuncNames {
-		if err := serialization.WriteString(w, fn); err != nil {
-			return err
-		}
-	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
-		return nil
-	}
-	return nil
-}
-
-func (this *FuncsToRoleParam) Deserialize(rd io.Reader) error {
-	var err error
-	var fnLen uint64
-	var i uint64
-
-	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.AdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if fnLen, err = serialization.ReadVarUint(rd, 0); err != nil {
-		return err
-	}
-	this.FuncNames = make([]string, fnLen)
-	for i = 0; i < fnLen; i++ {
-		fn, err := serialization.ReadString(rd)
-		if err != nil {
-			return err
-		}
-		this.FuncNames[i] = fn
-	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	return nil
-}
-
-type OntIDsToRoleParam struct {
-	ContractAddr []byte
-	AdminOntID   []byte
-	Role         []byte
-	Persons      [][]byte
-	KeyNo        uint32
-}
-
-func (this *OntIDsToRoleParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.AdminOntID); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarUint(w, uint64(len(this.Persons))); err != nil {
-		return err
-	}
-	for _, p := range this.Persons {
-		if err := serialization.WriteVarBytes(w, p); err != nil {
-			return err
-		}
-	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
-		return nil
-	}
-	return nil
-}
-
-func (this *OntIDsToRoleParam) Deserialize(rd io.Reader) error {
-	var err error
-	var pLen uint64
-	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.AdminOntID, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if pLen, err = serialization.ReadVarUint(rd, 0); err != nil {
-		return err
-	}
-	this.Persons = make([][]byte, pLen)
-	for i := uint64(0); i < pLen; i++ {
-		p, err := serialization.ReadVarBytes(rd)
-		if err != nil {
-			return err
-		}
-		this.Persons[i] = p
-	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	return nil
-}
-
-type DelegateParam struct {
-	ContractAddr []byte
-	From         []byte
-	To           []byte
-	Role         []byte
-	Period       uint32
-	Level        uint
-	KeyNo        uint32
-}
-
-func (this *DelegateParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.From); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.To); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
-		return err
-	}
-	if err := serialization.WriteUint32(w, this.Period); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarUint(w, uint64(this.Level)); err != nil {
-		return err
-	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (this *DelegateParam) Deserialize(rd io.Reader) error {
-	var err error
-	var period uint32
-	var level uint64
-	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.From, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.To, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Period, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	if level, err = serialization.ReadVarUint(rd, 0); err != nil {
-		return err
-	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	if level > math.MaxInt8 {
-		return fmt.Errorf("period or level too large: (%d, %d)", period, level)
-	}
-	this.Level = uint(level)
-	return nil
-}
-
-type WithdrawParam struct {
-	ContractAddr []byte
-	Initiator    []byte
-	Delegate     []byte
-	Role         []byte
-	KeyNo        uint32
-}
-
-func (this *WithdrawParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Initiator); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Delegate); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Role); err != nil {
-		return err
-	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
-		return err
-	}
-	return nil
-}
-func (this *WithdrawParam) Deserialize(rd io.Reader) error {
-	var err error
-	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Initiator, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Delegate, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Role, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	return nil
-}
-
-type VerifyTokenParam struct {
-	ContractAddr []byte
-	Caller       []byte
-	Fn           []byte
-	KeyNo        uint32
-}
-
-func (this *VerifyTokenParam) Serialize(w io.Writer) error {
-	if err := serialization.WriteVarBytes(w, this.ContractAddr); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Caller); err != nil {
-		return err
-	}
-	if err := serialization.WriteVarBytes(w, this.Fn); err != nil {
-		return err
-	}
-	if err := serialization.WriteUint32(w, this.KeyNo); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (this *VerifyTokenParam) Deserialize(rd io.Reader) error {
-	var err error
-	if this.ContractAddr, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.Caller, err = serialization.ReadVarBytes(rd); err != nil {
-		return err //deserialize caller error
-	}
-	if this.Fn, err = serialization.ReadVarBytes(rd); err != nil {
-		return err
-	}
-	if this.KeyNo, err = serialization.ReadUint32(rd); err != nil {
-		return err
-	}
-	return nil
-}
 
 /*
  * each role is assigned an array of funcNames
@@ -431,6 +97,63 @@ func (this *AuthToken) Deserialize(rd io.Reader) error {
 	return nil
 }
 
+type DelegateStatus struct {
+	root []byte
+	AuthToken
+}
+
+func (this *DelegateStatus) Serialize(w io.Writer) error {
+	if err := serialization.WriteVarBytes(w, this.root); err != nil {
+		return err
+	}
+	if err := this.AuthToken.Serialize(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *DelegateStatus) Deserialize(rd io.Reader) error {
+	var err error
+	this.root, err = serialization.ReadVarBytes(rd)
+	if err != nil {
+		return err
+	}
+	err = this.AuthToken.Deserialize(rd)
+	return err
+}
+
+type Status struct {
+	status []*DelegateStatus
+}
+
+func (this *Status) Serialize(w io.Writer) error {
+	if err := serialization.WriteUint32(w, uint32(len(this.status))); err != nil {
+		return err
+	}
+	for _, s := range this.status {
+		if err := s.Serialize(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (this *Status) Deserialize(rd io.Reader) error {
+	sLen, err := serialization.ReadUint32(rd)
+	if err != nil {
+		return err
+	}
+	this.status = make([]*DelegateStatus, sLen)
+	for i := uint32(0); i < sLen; i++ {
+		this.status[i] = new(DelegateStatus)
+		err = this.status[i].Deserialize(rd)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type roleTokens struct {
 	tokens []*AuthToken
 }
@@ -454,6 +177,7 @@ func (this *roleTokens) Deserialize(rd io.Reader) error {
 	}
 	this.tokens = make([]*AuthToken, tLen)
 	for i := uint32(0); i < tLen; i++ {
+		this.tokens[i] = new(AuthToken)
 		err = this.tokens[i].Deserialize(rd)
 		if err != nil {
 			return err

--- a/smartcontract/service/native/auth/state_test.go
+++ b/smartcontract/service/native/auth/state_test.go
@@ -210,8 +210,31 @@ func TestSerialization_VerifyToken(t *testing.T) {
 	}
 }
 
+func TestSerialization_roleFuncs(t *testing.T) {
+	param := &roleFuncs{
+		[]string{},
+	}
+	bf := new(bytes.Buffer)
+	if err := param.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+	rd := bytes.NewReader(bf.Bytes())
+	param2 := new(roleFuncs)
+	if err := param2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+	if len(param.funcNames) != len(param2.funcNames) {
+		t.Fatalf("does not match")
+	}
+	for i := 0; i < len(param.funcNames); i++ {
+		if param.funcNames[i] != param2.funcNames[i] {
+			t.Fatalf("%s \t %s does not match", param.funcNames[i], param2.funcNames[i])
+		}
+	}
+}
 func TestSerialization_AuthToken(t *testing.T) {
 	param := &AuthToken{
+		role:       []byte("role"),
 		expireTime: 1000000,
 		level:      2,
 	}
@@ -225,7 +248,28 @@ func TestSerialization_AuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	if param.expireTime != param2.expireTime ||
-		param.level != param2.level {
+		param.level != param2.level ||
+		bytes.Compare(param.role, param2.role) != 0 {
 		t.Fatalf("failed")
+	}
+}
+
+func TestSerialization_roleAuthTokens(t *testing.T) {
+	token1 := &AuthToken{
+		role:       []byte("role"),
+		expireTime: 1000000,
+		level:      2,
+	}
+	token2 := &AuthToken{
+		expireTime: 10000,
+		level:      2,
+		role:       []byte("role2"),
+	}
+	tokens := &roleTokens{
+		tokens: []*AuthToken{token1, token2},
+	}
+	bf := new(bytes.Buffer)
+	if err := tokens.Serialize(bf); err != nil {
+
 	}
 }

--- a/smartcontract/service/native/auth/state_test.go
+++ b/smartcontract/service/native/auth/state_test.go
@@ -20,199 +20,12 @@ package auth
 
 import (
 	"bytes"
-	"crypto/rand"
 	"testing"
 )
 
-var (
-	admin    []byte
-	newAdmin []byte
-	p1       []byte
-	p2       []byte
-)
-var (
-	funcs           = []string{"foo1", "foo2"}
-	role            = "role"
-	OntContractAddr = []byte{0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
-)
-
-func init() {
-	admin = make([]byte, 32)
-	newAdmin = make([]byte, 32)
-	p1 = make([]byte, 20)
-	p2 = make([]byte, 20)
-	rand.Read(admin)
-	rand.Read(newAdmin)
-	rand.Read(p1)
-	rand.Read(p2)
-}
-func TestSerialization_Init(t *testing.T) {
-	param := &InitContractAdminParam{
-		AdminOntID: admin,
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-
-	param2 := new(InitContractAdminParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Compare(param.AdminOntID, param2.AdminOntID) != 0 {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_Transfer(t *testing.T) {
-	param := &TransferParam{
-		ContractAddr:  OntContractAddr,
-		NewAdminOntID: newAdmin,
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-
-	param2 := new(TransferParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
-		bytes.Compare(param.NewAdminOntID, param2.NewAdminOntID) != 0 {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_AssignFuncs(t *testing.T) {
-	param := &FuncsToRoleParam{
-		ContractAddr: OntContractAddr,
-		AdminOntID:   admin,
-		Role:         []byte("role"),
-		FuncNames:    funcs,
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-
-	param2 := new(FuncsToRoleParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
-		bytes.Compare(param.AdminOntID, param2.AdminOntID) != 0 ||
-		bytes.Compare(param.Role, param2.Role) != 0 {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_AssignOntIDs(t *testing.T) {
-	param := &OntIDsToRoleParam{
-		ContractAddr: OntContractAddr,
-		AdminOntID:   admin,
-		Role:         []byte(role),
-		Persons:      [][]byte{[]byte{0x03, 0x04, 0x05, 0x06}, []byte{0x07, 0x08, 0x09, 0x0a}},
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-	param2 := new(OntIDsToRoleParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
-		bytes.Compare(param.AdminOntID, param2.AdminOntID) != 0 ||
-		bytes.Compare(param.Role, param2.Role) != 0 {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_Delegate(t *testing.T) {
-	param := &DelegateParam{
-		ContractAddr: OntContractAddr,
-		From:         p1,
-		To:           p2,
-		Role:         []byte(role),
-		Period:       60 * 60 * 24,
-		Level:        3,
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-	param2 := new(DelegateParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
-		bytes.Compare(param.From, param2.From) != 0 ||
-		bytes.Compare(param.To, param2.To) != 0 ||
-		bytes.Compare(param.Role, param2.Role) != 0 ||
-		param.Period != param2.Period || param.Level != param2.Level {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_Withdraw(t *testing.T) {
-	param := &WithdrawParam{
-		ContractAddr: OntContractAddr,
-		Initiator:    p1,
-		Delegate:     p2,
-		Role:         []byte(role),
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-	param2 := new(WithdrawParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
-		bytes.Compare(param.Initiator, param2.Initiator) != 0 ||
-		bytes.Compare(param.Delegate, param2.Delegate) != 0 ||
-		bytes.Compare(param.Role, param2.Role) != 0 {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_VerifyToken(t *testing.T) {
-	param := &VerifyTokenParam{
-		ContractAddr: OntContractAddr,
-		Caller:       p1,
-		Fn:           []byte("foo1"),
-	}
-	bf := new(bytes.Buffer)
-	if err := param.Serialize(bf); err != nil {
-		t.Fatal(err)
-	}
-	rd := bytes.NewReader(bf.Bytes())
-	param2 := new(VerifyTokenParam)
-	if err := param2.Deserialize(rd); err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare(param.ContractAddr, param2.ContractAddr) != 0 ||
-		bytes.Compare(param.Caller, param2.Caller) != 0 ||
-		bytes.Compare(param.Fn, param2.Fn) != 0 {
-		t.Fatalf("failed")
-	}
-}
-
-func TestSerialization_roleFuncs(t *testing.T) {
+func TestSer_roleFuncs(t *testing.T) {
 	param := &roleFuncs{
-		[]string{},
+		[]string{"foo1", "foo2"},
 	}
 	bf := new(bytes.Buffer)
 	if err := param.Serialize(bf); err != nil {
@@ -223,6 +36,7 @@ func TestSerialization_roleFuncs(t *testing.T) {
 	if err := param2.Deserialize(rd); err != nil {
 		t.Fatal(err)
 	}
+
 	if len(param.funcNames) != len(param2.funcNames) {
 		t.Fatalf("does not match")
 	}
@@ -232,12 +46,14 @@ func TestSerialization_roleFuncs(t *testing.T) {
 		}
 	}
 }
-func TestSerialization_AuthToken(t *testing.T) {
+
+func TestSer_AuthToken(t *testing.T) {
 	param := &AuthToken{
 		role:       []byte("role"),
 		expireTime: 1000000,
 		level:      2,
 	}
+
 	bf := new(bytes.Buffer)
 	if err := param.Serialize(bf); err != nil {
 		t.Fatal(err)
@@ -247,6 +63,7 @@ func TestSerialization_AuthToken(t *testing.T) {
 	if err := param2.Deserialize(rd); err != nil {
 		t.Fatal(err)
 	}
+
 	if param.expireTime != param2.expireTime ||
 		param.level != param2.level ||
 		bytes.Compare(param.role, param2.role) != 0 {
@@ -254,22 +71,71 @@ func TestSerialization_AuthToken(t *testing.T) {
 	}
 }
 
-func TestSerialization_roleAuthTokens(t *testing.T) {
+func TestSer_DelegateStatus(t *testing.T) {
+	/*
+		s1 := &DelegateStatus {
+			root: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+
+		}
+	*/
+}
+func TestSer_roleAuthTokens(t *testing.T) {
 	token1 := &AuthToken{
 		role:       []byte("role"),
 		expireTime: 1000000,
 		level:      2,
 	}
 	token2 := &AuthToken{
+		role:       []byte("role2"),
 		expireTime: 10000,
 		level:      2,
+	}
+
+	tokens := &roleTokens{
+		tokens: []*AuthToken{token1, token2},
+	}
+	bf := new(bytes.Buffer)
+	if err := tokens.Serialize(bf); err != nil {
+		t.Fatal(err)
+	}
+
+	tokens2 := new(roleTokens)
+	rd := bytes.NewReader(bf.Bytes())
+	if err := tokens2.Deserialize(rd); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tokens.tokens) != len(tokens2.tokens) {
+		t.Fatalf("failed")
+	}
+}
+
+/*
+func BenchmarkDes(b *testing.B) {
+	token1 := &AuthToken{
+		role:       []byte("role"),
+		expireTime: 1000000,
+		level:      2,
+	}
+	token2 := &AuthToken{
 		role:       []byte("role2"),
+		expireTime: 10000,
+		level:      2,
 	}
 	tokens := &roleTokens{
 		tokens: []*AuthToken{token1, token2},
 	}
 	bf := new(bytes.Buffer)
 	if err := tokens.Serialize(bf); err != nil {
+		b.Fatal(err)
+	}
 
+	for i := 0; i < b.N; i++ {
+		tokens2 := new(roleTokens)
+		rd := bytes.NewReader(bf.Bytes())
+		if err := tokens2.Deserialize(rd); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
+*/

--- a/smartcontract/service/native/auth/state_test.go
+++ b/smartcontract/service/native/auth/state_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 )
 
-func TestSer_roleFuncs(t *testing.T) {
+func TestSerRoleFuncs(t *testing.T) {
 	param := &roleFuncs{
 		[]string{"foo1", "foo2"},
+		//[]string{},
 	}
 	bf := new(bytes.Buffer)
 	if err := param.Serialize(bf); err != nil {
@@ -47,7 +48,7 @@ func TestSer_roleFuncs(t *testing.T) {
 	}
 }
 
-func TestSer_AuthToken(t *testing.T) {
+func TestSerAuthToken(t *testing.T) {
 	param := &AuthToken{
 		role:       []byte("role"),
 		expireTime: 1000000,
@@ -71,71 +72,29 @@ func TestSer_AuthToken(t *testing.T) {
 	}
 }
 
-func TestSer_DelegateStatus(t *testing.T) {
-	/*
-		s1 := &DelegateStatus {
-			root: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
-
-		}
-	*/
-}
-func TestSer_roleAuthTokens(t *testing.T) {
-	token1 := &AuthToken{
+func TestSerDelegateStatus(t *testing.T) {
+	token := &AuthToken{
 		role:       []byte("role"),
 		expireTime: 1000000,
 		level:      2,
 	}
-	token2 := &AuthToken{
-		role:       []byte("role2"),
-		expireTime: 10000,
-		level:      2,
-	}
-
-	tokens := &roleTokens{
-		tokens: []*AuthToken{token1, token2},
+	s1 := &DelegateStatus{
+		root:      []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+		AuthToken: *token,
 	}
 	bf := new(bytes.Buffer)
-	if err := tokens.Serialize(bf); err != nil {
+	if err := s1.Serialize(bf); err != nil {
 		t.Fatal(err)
 	}
-
-	tokens2 := new(roleTokens)
 	rd := bytes.NewReader(bf.Bytes())
-	if err := tokens2.Deserialize(rd); err != nil {
+	s2 := new(DelegateStatus)
+	if err := s2.Deserialize(rd); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(tokens.tokens) != len(tokens2.tokens) {
+	if bytes.Compare(s1.root, s2.root) != 0 ||
+		bytes.Compare(s1.role, s2.role) != 0 ||
+		s1.expireTime != s2.expireTime || s1.level != s2.level {
 		t.Fatalf("failed")
 	}
 }
-
-/*
-func BenchmarkDes(b *testing.B) {
-	token1 := &AuthToken{
-		role:       []byte("role"),
-		expireTime: 1000000,
-		level:      2,
-	}
-	token2 := &AuthToken{
-		role:       []byte("role2"),
-		expireTime: 10000,
-		level:      2,
-	}
-	tokens := &roleTokens{
-		tokens: []*AuthToken{token1, token2},
-	}
-	bf := new(bytes.Buffer)
-	if err := tokens.Serialize(bf); err != nil {
-		b.Fatal(err)
-	}
-
-	for i := 0; i < b.N; i++ {
-		tokens2 := new(roleTokens)
-		rd := bytes.NewReader(bf.Bytes())
-		if err := tokens2.Deserialize(rd); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-*/

--- a/smartcontract/service/native/auth/utils.go
+++ b/smartcontract/service/native/auth/utils.go
@@ -37,15 +37,15 @@ var (
 )
 
 //type(this.contractAddr.Admin) = []byte
-func GetContractAdminKey(native *native.NativeService, contractAddr []byte) ([]byte, error) {
+func concatContractAdminKey(native *native.NativeService, contractAddr []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
 	adminKey, err := packKeys(this[:], [][]byte{contractAddr, PreAdmin})
 
 	return adminKey, err
 }
 
-func GetContractAdmin(native *native.NativeService, contractAddr []byte) ([]byte, error) {
-	key, err := GetContractAdminKey(native, contractAddr)
+func getContractAdmin(native *native.NativeService, contractAddr []byte) ([]byte, error) {
+	key, err := concatContractAdminKey(native, contractAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +59,8 @@ func GetContractAdmin(native *native.NativeService, contractAddr []byte) ([]byte
 	return item.Value, nil
 }
 
-func PutContractAdmin(native *native.NativeService, contractAddr, adminOntID []byte) error {
-	key, err := GetContractAdminKey(native, contractAddr)
+func putContractAdmin(native *native.NativeService, contractAddr, adminOntID []byte) error {
+	key, err := concatContractAdminKey(native, contractAddr)
 	if err != nil {
 		return err
 	}
@@ -69,15 +69,15 @@ func PutContractAdmin(native *native.NativeService, contractAddr, adminOntID []b
 }
 
 //type(this.contractAddr.RoleFunc.role) = roleFuncs
-func GetRoleFuncKey(native *native.NativeService, contractAddr, role []byte) ([]byte, error) {
+func concatRoleFuncKey(native *native.NativeService, contractAddr, role []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
 	roleFuncKey, err := packKeys(this[:], [][]byte{contractAddr, PreRoleFunc, role})
 
 	return roleFuncKey, err
 }
 
-func GetRoleFunc(native *native.NativeService, contractAddr, role []byte) (*roleFuncs, error) {
-	key, err := GetRoleFuncKey(native, contractAddr, role)
+func getRoleFunc(native *native.NativeService, contractAddr, role []byte) (*roleFuncs, error) {
+	key, err := concatRoleFuncKey(native, contractAddr, role)
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +97,8 @@ func GetRoleFunc(native *native.NativeService, contractAddr, role []byte) (*role
 	return rF, nil
 }
 
-func PutRoleFunc(native *native.NativeService, contractAddr, role []byte, funcs *roleFuncs) error {
-	key, _ := GetRoleFuncKey(native, contractAddr, role)
+func putRoleFunc(native *native.NativeService, contractAddr, role []byte, funcs *roleFuncs) error {
+	key, _ := concatRoleFuncKey(native, contractAddr, role)
 	bf := new(bytes.Buffer)
 	err := funcs.Serialize(bf)
 	if err != nil {
@@ -109,15 +109,15 @@ func PutRoleFunc(native *native.NativeService, contractAddr, role []byte, funcs 
 }
 
 //type(this.contractAddr.RoleP.ontID) = roleTokens
-func GetOntIDTokenKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
+func concatOntIDTokenKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
 	tokenKey, err := packKeys(this[:], [][]byte{contractAddr, PreRoleToken, ontID})
 
 	return tokenKey, err
 }
 
-func GetOntIDToken(native *native.NativeService, contractAddr, ontID []byte) (*roleTokens, error) {
-	key, err := GetOntIDTokenKey(native, contractAddr, ontID)
+func getOntIDToken(native *native.NativeService, contractAddr, ontID []byte) (*roleTokens, error) {
+	key, err := concatOntIDTokenKey(native, contractAddr, ontID)
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +137,8 @@ func GetOntIDToken(native *native.NativeService, contractAddr, ontID []byte) (*r
 	return rT, nil
 }
 
-func PutOntIDToken(native *native.NativeService, contractAddr, ontID []byte, tokens *roleTokens) error {
-	key, _ := GetOntIDTokenKey(native, contractAddr, ontID)
+func putOntIDToken(native *native.NativeService, contractAddr, ontID []byte, tokens *roleTokens) error {
+	key, _ := concatOntIDTokenKey(native, contractAddr, ontID)
 	bf := new(bytes.Buffer)
 	err := tokens.Serialize(bf)
 	if err != nil {
@@ -149,15 +149,15 @@ func PutOntIDToken(native *native.NativeService, contractAddr, ontID []byte, tok
 }
 
 //type(this.contractAddr.DelegateStatus.ontID)
-func GetDelegateStatusKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
+func concatDelegateStatusKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
 	key, err := packKeys(this[:], [][]byte{contractAddr, PreDelegateStatus, ontID})
 
 	return key, err
 }
 
-func GetDelegateStatus(native *native.NativeService, contractAddr, ontID []byte) (*Status, error) {
-	key, err := GetDelegateStatusKey(native, contractAddr, ontID)
+func getDelegateStatus(native *native.NativeService, contractAddr, ontID []byte) (*Status, error) {
+	key, err := concatDelegateStatusKey(native, contractAddr, ontID)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +177,8 @@ func GetDelegateStatus(native *native.NativeService, contractAddr, ontID []byte)
 	return status, nil
 }
 
-func PutDelegateStatus(native *native.NativeService, contractAddr, ontID []byte, status *Status) error {
-	key, _ := GetDelegateStatusKey(native, contractAddr, ontID)
+func putDelegateStatus(native *native.NativeService, contractAddr, ontID []byte, status *Status) error {
+	key, _ := concatDelegateStatusKey(native, contractAddr, ontID)
 	bf := new(bytes.Buffer)
 	err := status.Serialize(bf)
 	if err != nil {

--- a/smartcontract/service/native/auth/utils.go
+++ b/smartcontract/service/native/auth/utils.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/common/serialization"
 	"github.com/ontio/ontology/smartcontract/event"
 	"github.com/ontio/ontology/smartcontract/service/native"
@@ -39,7 +40,7 @@ var (
 //type(this.contractAddr.Admin) = []byte
 func concatContractAdminKey(native *native.NativeService, contractAddr []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	adminKey, err := packKeys(this[:], [][]byte{contractAddr, PreAdmin})
+	adminKey, err := packKeys(this, [][]byte{contractAddr, PreAdmin})
 
 	return adminKey, err
 }
@@ -71,7 +72,7 @@ func putContractAdmin(native *native.NativeService, contractAddr, adminOntID []b
 //type(this.contractAddr.RoleFunc.role) = roleFuncs
 func concatRoleFuncKey(native *native.NativeService, contractAddr, role []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	roleFuncKey, err := packKeys(this[:], [][]byte{contractAddr, PreRoleFunc, role})
+	roleFuncKey, err := packKeys(this, [][]byte{contractAddr, PreRoleFunc, role})
 
 	return roleFuncKey, err
 }
@@ -111,7 +112,7 @@ func putRoleFunc(native *native.NativeService, contractAddr, role []byte, funcs 
 //type(this.contractAddr.RoleP.ontID) = roleTokens
 func concatOntIDTokenKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	tokenKey, err := packKeys(this[:], [][]byte{contractAddr, PreRoleToken, ontID})
+	tokenKey, err := packKeys(this, [][]byte{contractAddr, PreRoleToken, ontID})
 
 	return tokenKey, err
 }
@@ -151,7 +152,7 @@ func putOntIDToken(native *native.NativeService, contractAddr, ontID []byte, tok
 //type(this.contractAddr.DelegateStatus.ontID)
 func concatDelegateStatusKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	key, err := packKeys(this[:], [][]byte{contractAddr, PreDelegateStatus, ontID})
+	key, err := packKeys(this, [][]byte{contractAddr, PreDelegateStatus, ontID})
 
 	return key, err
 }
@@ -192,7 +193,7 @@ func putDelegateStatus(native *native.NativeService, contractAddr, ontID []byte,
  * pack data to be used as a key in the kv storage
  * key := field || ser_items[1] || ... || ser_items[n]
  */
-func packKeys(field []byte, items [][]byte) ([]byte, error) {
+func packKeys(field common.Address, items [][]byte) ([]byte, error) {
 	w := new(bytes.Buffer)
 	for _, item := range items {
 		err := serialization.WriteVarBytes(w, item)
@@ -200,7 +201,7 @@ func packKeys(field []byte, items [][]byte) ([]byte, error) {
 			return nil, fmt.Errorf("packKeys failed when serialize %x", item)
 		}
 	}
-	key := append(field, w.Bytes()...)
+	key := append(field[:], w.Bytes()...)
 	return key, nil
 }
 
@@ -208,7 +209,7 @@ func packKeys(field []byte, items [][]byte) ([]byte, error) {
  * pack data to be used as a key in the kv storage
  * key := field || ser_data
  */
-func packKey(field []byte, data []byte) ([]byte, error) {
+func packKey(field common.Address, data []byte) ([]byte, error) {
 	return packKeys(field, [][]byte{data})
 }
 

--- a/smartcontract/service/native/auth/utils.go
+++ b/smartcontract/service/native/auth/utils.go
@@ -19,68 +19,84 @@
 package auth
 
 import (
-	"github.com/ontio/ontology/core/states"
-	"github.com/ontio/ontology/core/store/common"
+	"bytes"
+	"fmt"
+
+	"github.com/ontio/ontology/common/serialization"
 	"github.com/ontio/ontology/smartcontract/service/native"
 )
 
 var (
 	RoleF        = []byte{0x01}
 	RoleP        = []byte{0x02}
-	FuncPerson   = []byte{0x03}
 	DelegateList = []byte{0x04}
 	Admin        = []byte{0x05}
 )
 
-//this.contractAddr.Admin
+//type(this.contractAddr.Admin) = []byte
 func GetContractAdminKey(native *native.NativeService, contractAddr []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	adminKey, err := PackKeys(this[:], [][]byte{contractAddr, Admin})
+	adminKey, err := packKeys(this[:], [][]byte{contractAddr, Admin})
 
 	return adminKey, err
 }
 
-//this.contractAddr.RoleF.role
+//type(this.contractAddr.RoleF.role) = roleFuncs
 func GetRoleFKey(native *native.NativeService, contractAddr, role []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	roleFKey, err := PackKeys(this[:], [][]byte{contractAddr, RoleF, role})
+	roleFKey, err := packKeys(this[:], [][]byte{contractAddr, RoleF, role})
 
 	return roleFKey, err
 }
 
-//this.contractAddr.RoleP.role
-func GetRolePKey(native *native.NativeService, contractAddr, role []byte) ([]byte, error) {
+//type(this.contractAddr.RoleP.ontID) = roleTokens
+func GetRolePKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	rolePKey, err := PackKeys(this[:], [][]byte{contractAddr, RoleP, role})
+	rolePKey, err := packKeys(this[:], [][]byte{contractAddr, RoleP, ontID})
 
 	return rolePKey, err
 }
 
-//this.contractAddr.FuncOntID.func.ontID
-func GetFuncOntIDKey(native *native.NativeService, contractAddr, fn, ontID []byte) ([]byte, error) {
-	this := native.ContextRef.CurrentContext().ContractAddress
-	funcOntIDKey, err := PackKeys(this[:], [][]byte{contractAddr, FuncPerson, fn, ontID})
-
-	return funcOntIDKey, err
-}
-
-//this.contractAddr.DelegateList.role.ontID
+//type(this.contractAddr.DelegateList.role.ontID)
 func GetDelegateListKey(native *native.NativeService, contractAddr, role, ontID []byte) ([]byte, error) {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	delegateListKey, err := PackKeys(this[:], [][]byte{contractAddr, DelegateList, role, ontID})
+	delegateListKey, err := packKeys(this[:], [][]byte{contractAddr, DelegateList, role, ontID})
 
 	return delegateListKey, err
 }
 
-func PutBytes(native *native.NativeService, key []byte, value []byte) {
-	native.CloneCache.Add(common.ST_STORAGE, key, &states.StorageItem{Value: value})
+//remote duplicates in the slice of string
+func stringSliceUniq(s []string) []string {
+	smap := make(map[string]int)
+	for i, str := range s {
+		if str == "" {
+			continue
+		}
+		smap[str] = i
+	}
+	ret := make([]string, len(smap))
+	i := 0
+	for str, _ := range smap {
+		ret[i] = str
+		i++
+	}
+	return ret
 }
 
-func writeAuthToken(native *native.NativeService, contractAddr, fn, ontID, auth []byte) error {
-	key, err := GetFuncOntIDKey(native, contractAddr, fn, ontID)
-	if err != nil {
-		return err
+func packKeys(field []byte, items [][]byte) ([]byte, error) {
+	w := new(bytes.Buffer)
+	for _, item := range items {
+		err := serialization.WriteVarBytes(w, item)
+		if err != nil {
+			return nil, fmt.Errorf("packKeys failed when serialize %x", item)
+		}
 	}
-	PutBytes(native, key, auth)
-	return nil
+	key := append(field, w.Bytes()...)
+	return key, nil
+}
+
+//pack data to be used as a key in the kv storage
+// key := field || ser_data
+func packKey(field []byte, data []byte) ([]byte, error) {
+	return packKeys(field, [][]byte{data})
 }

--- a/smartcontract/service/native/auth/utils_test.go
+++ b/smartcontract/service/native/auth/utils_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import "testing"
+
+//{"a", "b"} == {"b", "a"}
+func testEq(a, b []string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+	Map := make(map[string]bool)
+	for i := range a {
+		Map[a[i]] = true
+	}
+	for _, s := range b {
+		_, ok := Map[s]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+func TestStringSliceUniq(t *testing.T) {
+	s := []string{"foo", "foo1", "foo2", "foo", "foo1", "foo2", "foo3"}
+	ret := stringSliceUniq(s)
+	t.Log(ret)
+	if !testEq(ret, []string{"foo", "foo1", "foo2", "foo3"}) {
+		t.Fatalf("failed")
+	}
+}

--- a/smartcontract/service/native/auth/utils_test.go
+++ b/smartcontract/service/native/auth/utils_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package auth
 
 import "testing"


### PR DESCRIPTION
The old contract has the problem that use a lot of storage to store a big table, i.e. OntID x Func -> authToken. In this PR, we make a tradeoff between space and time complexity by computing the table implicitly during runtime. In particular, we compute the table implicitly by join the OntID -> [](role, authToken) table and role -> []funcs.