### PR TITLE
fix usage of reader.Read

### DIFF
--- a/cmd/utils/export.go
+++ b/cmd/utils/export.go
@@ -73,7 +73,7 @@ func (this *ExportBlockMetadata) Serialize(w io.Writer) error {
 
 func (this *ExportBlockMetadata) Deserialize(r io.Reader) error {
 	metadata := make([]byte, EXPORT_BLOCK_METADATA_LEN, EXPORT_BLOCK_METADATA_LEN)
-	_, err := r.Read(metadata)
+	_, err := io.ReadFull(r, metadata)
 	if err != nil {
 		return err
 	}

--- a/common/address.go
+++ b/common/address.go
@@ -47,8 +47,8 @@ func (self *Address) Serialize(w io.Writer) error {
 
 // Deserialize deserialize Address from io.Reader
 func (self *Address) Deserialize(r io.Reader) error {
-	n, err := r.Read(self[:])
-	if n != len(self[:]) || err != nil {
+	_, err := io.ReadFull(r, self[:])
+	if err != nil {
 		return errors.New("deserialize Address error")
 	}
 	return nil

--- a/common/serialization/serialize.go
+++ b/common/serialization/serialize.go
@@ -100,25 +100,25 @@ func ReadVarUint(reader io.Reader, maxint uint64) (uint64, error) {
 		maxint = math.MaxUint64
 	}
 	var fb [9]byte
-	_, err := reader.Read(fb[:1])
+	_, err := io.ReadFull(reader, fb[:1])
 	if err != nil {
 		return 0, err
 	}
 
 	if fb[0] == byte(0xfd) {
-		_, err := reader.Read(fb[1:3])
+		_, err := io.ReadFull(reader, fb[1:3])
 		if err != nil {
 			return 0, err
 		}
 		res = uint64(binary.LittleEndian.Uint16(fb[1:3]))
 	} else if fb[0] == byte(0xfe) {
-		_, err := reader.Read(fb[1:5])
+		_, err := io.ReadFull(reader, fb[1:5])
 		if err != nil {
 			return 0, err
 		}
 		res = uint64(binary.LittleEndian.Uint32(fb[1:5]))
 	} else if fb[0] == byte(0xff) {
-		_, err := reader.Read(fb[1:9])
+		_, err := io.ReadFull(reader, fb[1:9])
 		if err != nil {
 			return 0, err
 		}
@@ -187,8 +187,8 @@ func ReadBytes(reader io.Reader, length uint64) ([]byte, error) {
 
 func ReadUint8(reader io.Reader) (uint8, error) {
 	var p [1]byte
-	n, err := reader.Read(p[:])
-	if n != 1 || err != nil {
+	_, err := io.ReadFull(reader, p[:])
+	if err != nil {
 		return 0, ErrEof
 	}
 	return uint8(p[0]), nil
@@ -196,8 +196,8 @@ func ReadUint8(reader io.Reader) (uint8, error) {
 
 func ReadUint16(reader io.Reader) (uint16, error) {
 	var p [2]byte
-	n, err := reader.Read(p[:])
-	if n != 2 || err != nil {
+	_, err := io.ReadFull(reader, p[:])
+	if err != nil {
 		return 0, ErrEof
 	}
 	return binary.LittleEndian.Uint16(p[:]), nil
@@ -205,8 +205,8 @@ func ReadUint16(reader io.Reader) (uint16, error) {
 
 func ReadUint32(reader io.Reader) (uint32, error) {
 	var p [4]byte
-	n, err := reader.Read(p[:])
-	if n != 4 || err != nil {
+	_, err := io.ReadFull(reader, p[:])
+	if err != nil {
 		return 0, ErrEof
 	}
 	return binary.LittleEndian.Uint32(p[:]), nil
@@ -214,8 +214,8 @@ func ReadUint32(reader io.Reader) (uint32, error) {
 
 func ReadUint64(reader io.Reader) (uint64, error) {
 	var p [8]byte
-	n, err := reader.Read(p[:])
-	if n != 8 || err != nil {
+	_, err := io.ReadFull(reader, p[:])
+	if err != nil {
 		return 0, ErrEof
 	}
 	return binary.LittleEndian.Uint64(p[:]), nil
@@ -270,16 +270,16 @@ func byteXReader(reader io.Reader, x uint64) ([]byte, error) {
 	var p []byte
 	var tmp [LEN]byte
 	for x > LEN {
-		n, err := reader.Read(tmp[:])
-		if n != LEN || err != nil {
+		_, err := io.ReadFull(reader, tmp[:])
+		if err != nil {
 			return nil, ErrEof
 		}
 		p = append(p, tmp[:]...)
 		x -= LEN
 	}
 
-	n, err := reader.Read(tmp[:x])
-	if n != int(x) || err != nil {
+	_, err := io.ReadFull(reader, tmp[:x])
+	if err != nil {
 		return nil, ErrEof
 	}
 	p = append(p, tmp[:x]...)

--- a/common/uint256.go
+++ b/common/uint256.go
@@ -49,8 +49,8 @@ func (u *Uint256) Serialize(w io.Writer) error {
 }
 
 func (u *Uint256) Deserialize(r io.Reader) error {
-	n, err := r.Read(u[:])
-	if n != len(u[:]) || err != nil {
+	_, err := io.ReadFull(r, u[:])
+	if err != nil {
 		return errors.New("deserialize Uint256 error")
 	}
 	return nil

--- a/consensus/vbft/config/config.go
+++ b/consensus/vbft/config/config.go
@@ -104,7 +104,7 @@ func (cc *ChainConfig) Serialize(w io.Writer) error {
 
 func (cc *ChainConfig) Deserialize(r io.Reader, length int) error {
 	buf := make([]byte, length)
-	if _, err := r.Read(buf[:]); err != nil {
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(buf[:], &cc); err != nil {

--- a/core/payload/bookkeeper.go
+++ b/core/payload/bookkeeper.go
@@ -76,8 +76,8 @@ func (self *Bookkeeper) Deserialize(r io.Reader) error {
 	}
 
 	var p [1]byte
-	n, err := r.Read(p[:])
-	if n == 0 {
+	_, err = io.ReadFull(r, p[:])
+	if err != nil {
 		return fmt.Errorf("[Bookkeeper], deserializing Action failed: %s", err)
 	}
 	self.Action = BookkeeperAction(p[0])

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -225,7 +225,10 @@ func (tx *Transaction) Deserialize(r io.Reader) error {
 
 func (tx *Transaction) DeserializeUnsigned(r io.Reader) error {
 	var versiontype [2]byte
-	r.Read(versiontype[:])
+	_, err := io.ReadFull(r, versiontype[:])
+	if err != nil {
+		return err
+	}
 	nonce, err := serialization.ReadUint32(r)
 	if err != nil {
 		return err

--- a/smartcontract/service/native/global_params/states.go
+++ b/smartcontract/service/native/global_params/states.go
@@ -102,8 +102,8 @@ func (admin *Admin) Serialize(w io.Writer) error {
 }
 
 func (admin *Admin) Deserialize(r io.Reader) error {
-	n, err := r.Read(admin[:])
-	if n != len(admin[:]) || err != nil {
+	_, err := io.ReadFull(r, admin[:])
+	if err != nil {
 		return errors.NewDetailErr(err, errors.ErrNoCode, "param config, deserialize admin error!")
 	}
 	return nil


### PR DESCRIPTION
`n, err := reader.Read(p[:])`  can return `n < len(p), err = nil`,
which is not handled properly in current code. and will cause subtle bugs

Signed-off-by: laizy <laizhichao@onchain.com>