### PR TITLE
ONT-828 use common.Address type

### DIFF
--- a/smartcontract/service/native/auth/auth.go
+++ b/smartcontract/service/native/auth/auth.go
@@ -614,7 +614,7 @@ func verifySig(native *native.NativeService, ontID []byte, keyNo uint64) (bool, 
 	if err := serialization.WriteVarBytes(bf, ontID); err != nil {
 		return false, err
 	}
-	if err := serialization.WriteVarUint(bf, keyNo); err != nil {
+	if err := utils.WriteVarUint(bf, keyNo); err != nil {
 		return false, err
 	}
 	args := bf.Bytes()

--- a/smartcontract/service/native/auth/auth.go
+++ b/smartcontract/service/native/auth/auth.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/common/serialization"
 	"github.com/ontio/ontology/errors"
 	"github.com/ontio/ontology/smartcontract/service/native"
@@ -41,7 +42,7 @@ func Init() {
 /*
  * contract admin management
  */
-func initContractAdmin(native *native.NativeService, contractAddr, ontID []byte) (bool, error) {
+func initContractAdmin(native *native.NativeService, contractAddr common.Address, ontID []byte) (bool, error) {
 	admin, err := getContractAdmin(native, contractAddr)
 	if err != nil {
 		return false, err
@@ -69,7 +70,7 @@ func InitContractAdmin(native *native.NativeService) ([]byte, error) {
 	}
 	invokeAddr := cxt.ContractAddress
 
-	ret, err := initContractAdmin(native, invokeAddr[:], param.AdminOntID)
+	ret, err := initContractAdmin(native, invokeAddr, param.AdminOntID)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func InitContractAdmin(native *native.NativeService) ([]byte, error) {
 	return utils.BYTE_TRUE, nil
 }
 
-func transfer(native *native.NativeService, contractAddr, newAdminOntID []byte, keyNo uint64) (bool, error) {
+func transfer(native *native.NativeService, contractAddr common.Address, newAdminOntID []byte, keyNo uint64) (bool, error) {
 	admin, err := getContractAdmin(native, contractAddr)
 	if err != nil {
 		return false, err
@@ -99,10 +100,7 @@ func transfer(native *native.NativeService, contractAddr, newAdminOntID []byte, 
 		return false, nil
 	}
 
-	adminKey, err := concatContractAdminKey(native, contractAddr)
-	if err != nil {
-		return false, err
-	}
+	adminKey := concatContractAdminKey(native, contractAddr)
 	utils.PutBytes(native, adminKey, newAdminOntID)
 	return true, nil
 }
@@ -123,8 +121,7 @@ func Transfer(native *native.NativeService) ([]byte, error) {
 	sucState := []interface{}{"transfer", contract, true}
 
 	//call transfer func
-	contractAddr := param.ContractAddr[:]
-	ret, err := transfer(native, contractAddr, param.NewAdminOntID, param.KeyNo)
+	ret, err := transfer(native, param.ContractAddr, param.NewAdminOntID, param.KeyNo)
 	if ret {
 		pushEvent(native, sucState)
 		return utils.BYTE_TRUE, nil
@@ -153,8 +150,7 @@ func AssignFuncsToRole(native *native.NativeService) ([]byte, error) {
 	}
 
 	//check the caller's permission
-	contractAddr := param.ContractAddr[:]
-	admin, err := getContractAdmin(native, contractAddr)
+	admin, err := getContractAdmin(native, param.ContractAddr)
 	if err != nil {
 		return nil, fmt.Errorf("get contract admin failed, caused by %v", err)
 	}
@@ -175,7 +171,7 @@ func AssignFuncsToRole(native *native.NativeService) ([]byte, error) {
 		return utils.BYTE_FALSE, nil
 	}
 
-	funcs, err := getRoleFunc(native, contractAddr, param.Role)
+	funcs, err := getRoleFunc(native, param.ContractAddr, param.Role)
 	if funcs != nil {
 		funcNames := append(funcs.funcNames, param.FuncNames...)
 		funcs.funcNames = stringSliceUniq(funcNames)
@@ -183,7 +179,7 @@ func AssignFuncsToRole(native *native.NativeService) ([]byte, error) {
 		funcs = new(roleFuncs)
 		funcs.funcNames = stringSliceUniq(param.FuncNames)
 	}
-	err = putRoleFunc(native, contractAddr, param.Role, funcs)
+	err = putRoleFunc(native, param.ContractAddr, param.Role, funcs)
 	if err != nil {
 		return utils.BYTE_FALSE, err
 	}
@@ -194,8 +190,7 @@ func AssignFuncsToRole(native *native.NativeService) ([]byte, error) {
 
 func assignToRole(native *native.NativeService, param *OntIDsToRoleParam) (bool, error) {
 	//check admin's permission
-	contractAddr := param.ContractAddr[:]
-	admin, err := getContractAdmin(native, contractAddr)
+	admin, err := getContractAdmin(native, param.ContractAddr)
 	if err != nil {
 		return false, fmt.Errorf("get contract admin failed, caused by %v", err)
 	}
@@ -223,7 +218,7 @@ func assignToRole(native *native.NativeService, param *OntIDsToRoleParam) (bool,
 		if p == nil {
 			continue
 		}
-		tokens, err := getOntIDToken(native, contractAddr, p)
+		tokens, err := getOntIDToken(native, param.ContractAddr, p)
 		if err != nil {
 			return false, err
 		}
@@ -232,7 +227,7 @@ func assignToRole(native *native.NativeService, param *OntIDsToRoleParam) (bool,
 			tokens.tokens = make([]*AuthToken, 1)
 			tokens.tokens[0] = token
 		} else {
-			ret, err := hasRole(native, contractAddr, p, param.Role)
+			ret, err := hasRole(native, param.ContractAddr, p, param.Role)
 			if err != nil {
 				return false, err
 			}
@@ -242,7 +237,7 @@ func assignToRole(native *native.NativeService, param *OntIDsToRoleParam) (bool,
 				continue
 			}
 		}
-		err = putOntIDToken(native, contractAddr, p, tokens)
+		err = putOntIDToken(native, param.ContractAddr, p, tokens)
 		if err != nil {
 			return false, err
 		}
@@ -278,7 +273,7 @@ func AssignOntIDsToRole(native *native.NativeService) ([]byte, error) {
 	}
 }
 
-func getAuthToken(native *native.NativeService, contractAddr, ontID, role []byte) (*AuthToken, error) {
+func getAuthToken(native *native.NativeService, contractAddr common.Address, ontID, role []byte) (*AuthToken, error) {
 	tokens, err := getOntIDToken(native, contractAddr, ontID)
 	if err != nil {
 		return nil, fmt.Errorf("get token failed, caused by %v", err)
@@ -308,7 +303,7 @@ func getAuthToken(native *native.NativeService, contractAddr, ontID, role []byte
 	return nil, nil
 }
 
-func hasRole(native *native.NativeService, contractAddr, ontID, role []byte) (bool, error) {
+func hasRole(native *native.NativeService, contractAddr common.Address, ontID, role []byte) (bool, error) {
 	token, err := getAuthToken(native, contractAddr, ontID, role)
 	if err != nil {
 		return false, err
@@ -319,7 +314,7 @@ func hasRole(native *native.NativeService, contractAddr, ontID, role []byte) (bo
 	return true, nil
 }
 
-func getLevel(native *native.NativeService, contractAddr, ontID, role []byte) (uint8, error) {
+func getLevel(native *native.NativeService, contractAddr common.Address, ontID, role []byte) (uint8, error) {
 	token, err := getAuthToken(native, contractAddr, ontID, role)
 	if err != nil {
 		return 0, err
@@ -334,7 +329,7 @@ func getLevel(native *native.NativeService, contractAddr, ontID, role []byte) (u
  * if 'from' has the authority and 'to' has not been authorized 'role',
  * then make changes to storage as follows:
  */
-func delegate(native *native.NativeService, contractAddr []byte, from []byte, to []byte,
+func delegate(native *native.NativeService, contractAddr common.Address, from []byte, to []byte,
 	role []byte, period uint32, level uint8, keyNo uint64) (bool, error) {
 	var fromHasRole, toHasRole bool
 	var fromLevel uint8
@@ -443,8 +438,7 @@ func Delegate(native *native.NativeService) ([]byte, error) {
 	sucState := []interface{}{"delegate", contract, param.From, param.To, true}
 
 	//call the delegate func
-	contractAddr := param.ContractAddr[:]
-	ret, err := delegate(native, contractAddr, param.From, param.To, param.Role,
+	ret, err := delegate(native, param.ContractAddr, param.From, param.To, param.Role,
 		uint32(param.Period), uint8(param.Level), param.KeyNo)
 	if err != nil {
 		return nil, err
@@ -458,7 +452,7 @@ func Delegate(native *native.NativeService) ([]byte, error) {
 	}
 }
 
-func withdraw(native *native.NativeService, contractAddr []byte, initiator []byte, delegate []byte,
+func withdraw(native *native.NativeService, contractAddr common.Address, initiator []byte, delegate []byte,
 	role []byte, keyNo uint64) (bool, error) {
 	//check from's permission
 	ret, err := verifySig(native, initiator, keyNo)
@@ -516,8 +510,7 @@ func Withdraw(native *native.NativeService) ([]byte, error) {
 	sucState := []interface{}{"withdraw", contract, param.Initiator, param.Delegate, true}
 
 	//call the withdraw func
-	contractAddr := param.ContractAddr[:]
-	ret, err := withdraw(native, contractAddr, param.Initiator, param.Delegate, param.Role, param.KeyNo)
+	ret, err := withdraw(native, param.ContractAddr, param.Initiator, param.Delegate, param.Role, param.KeyNo)
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +529,7 @@ func Withdraw(native *native.NativeService) ([]byte, error) {
  *  @fn the name of the func to call
  *  @tokenSig the signature on the message
  */
-func verifyToken(native *native.NativeService, contractAddr []byte, caller []byte, fn string, keyNo uint64) (bool, error) {
+func verifyToken(native *native.NativeService, contractAddr common.Address, caller []byte, fn string, keyNo uint64) (bool, error) {
 	//check caller's identity
 	ret, err := verifySig(native, caller, keyNo)
 	if err != nil {
@@ -604,8 +597,7 @@ func VerifyToken(native *native.NativeService) ([]byte, error) {
 	failState := []interface{}{"verifyToken", contract, param.Caller, param.Fn, false}
 	sucState := []interface{}{"verifyToken", contract, param.Caller, param.Fn, true}
 
-	contractAddr := param.ContractAddr[:]
-	ret, err := verifyToken(native, contractAddr, param.Caller, param.Fn, param.KeyNo)
+	ret, err := verifyToken(native, param.ContractAddr, param.Caller, param.Fn, param.KeyNo)
 	if err != nil {
 		return nil, err
 	}

--- a/smartcontract/service/native/auth/utils.go
+++ b/smartcontract/service/native/auth/utils.go
@@ -35,22 +35,19 @@ var (
 	PreRoleFunc       = []byte{0x02}
 	PreRoleToken      = []byte{0x03}
 	PreDelegateStatus = []byte{0x04}
-	//PreDelegateList   = []byte{0x04}
 )
 
 //type(this.contractAddr.Admin) = []byte
-func concatContractAdminKey(native *native.NativeService, contractAddr []byte) ([]byte, error) {
+func concatContractAdminKey(native *native.NativeService, contractAddr common.Address) []byte {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	adminKey, err := packKeys(this, [][]byte{contractAddr, PreAdmin})
+	adminKey := append(this[:], contractAddr[:]...)
+	adminKey = append(adminKey, PreAdmin...)
 
-	return adminKey, err
+	return adminKey
 }
 
-func getContractAdmin(native *native.NativeService, contractAddr []byte) ([]byte, error) {
-	key, err := concatContractAdminKey(native, contractAddr)
-	if err != nil {
-		return nil, err
-	}
+func getContractAdmin(native *native.NativeService, contractAddr common.Address) ([]byte, error) {
+	key := concatContractAdminKey(native, contractAddr)
 	item, err := utils.GetStorageItem(native, key)
 	if err != nil {
 		return nil, err
@@ -61,28 +58,24 @@ func getContractAdmin(native *native.NativeService, contractAddr []byte) ([]byte
 	return item.Value, nil
 }
 
-func putContractAdmin(native *native.NativeService, contractAddr, adminOntID []byte) error {
-	key, err := concatContractAdminKey(native, contractAddr)
-	if err != nil {
-		return err
-	}
+func putContractAdmin(native *native.NativeService, contractAddr common.Address, adminOntID []byte) error {
+	key := concatContractAdminKey(native, contractAddr)
 	utils.PutBytes(native, key, adminOntID)
 	return nil
 }
 
 //type(this.contractAddr.RoleFunc.role) = roleFuncs
-func concatRoleFuncKey(native *native.NativeService, contractAddr, role []byte) ([]byte, error) {
+func concatRoleFuncKey(native *native.NativeService, contractAddr common.Address, role []byte) []byte {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	roleFuncKey, err := packKeys(this, [][]byte{contractAddr, PreRoleFunc, role})
+	roleFuncKey := append(this[:], contractAddr[:]...)
+	roleFuncKey = append(roleFuncKey, PreRoleFunc...)
+	roleFuncKey = append(roleFuncKey, role...)
 
-	return roleFuncKey, err
+	return roleFuncKey
 }
 
-func getRoleFunc(native *native.NativeService, contractAddr, role []byte) (*roleFuncs, error) {
-	key, err := concatRoleFuncKey(native, contractAddr, role)
-	if err != nil {
-		return nil, err
-	}
+func getRoleFunc(native *native.NativeService, contractAddr common.Address, role []byte) (*roleFuncs, error) {
+	key := concatRoleFuncKey(native, contractAddr, role)
 	item, err := utils.GetStorageItem(native, key)
 	if err != nil {
 		return nil, err
@@ -99,8 +92,8 @@ func getRoleFunc(native *native.NativeService, contractAddr, role []byte) (*role
 	return rF, nil
 }
 
-func putRoleFunc(native *native.NativeService, contractAddr, role []byte, funcs *roleFuncs) error {
-	key, _ := concatRoleFuncKey(native, contractAddr, role)
+func putRoleFunc(native *native.NativeService, contractAddr common.Address, role []byte, funcs *roleFuncs) error {
+	key := concatRoleFuncKey(native, contractAddr, role)
 	bf := new(bytes.Buffer)
 	err := funcs.Serialize(bf)
 	if err != nil {
@@ -111,18 +104,17 @@ func putRoleFunc(native *native.NativeService, contractAddr, role []byte, funcs 
 }
 
 //type(this.contractAddr.RoleP.ontID) = roleTokens
-func concatOntIDTokenKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
+func concatOntIDTokenKey(native *native.NativeService, contractAddr common.Address, ontID []byte) []byte {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	tokenKey, err := packKeys(this, [][]byte{contractAddr, PreRoleToken, ontID})
+	tokenKey := append(this[:], contractAddr[:]...)
+	tokenKey = append(tokenKey, PreRoleToken...)
+	tokenKey = append(tokenKey, ontID...)
 
-	return tokenKey, err
+	return tokenKey
 }
 
-func getOntIDToken(native *native.NativeService, contractAddr, ontID []byte) (*roleTokens, error) {
-	key, err := concatOntIDTokenKey(native, contractAddr, ontID)
-	if err != nil {
-		return nil, err
-	}
+func getOntIDToken(native *native.NativeService, contractAddr common.Address, ontID []byte) (*roleTokens, error) {
+	key := concatOntIDTokenKey(native, contractAddr, ontID)
 	item, err := utils.GetStorageItem(native, key)
 	if err != nil {
 		return nil, err
@@ -139,8 +131,8 @@ func getOntIDToken(native *native.NativeService, contractAddr, ontID []byte) (*r
 	return rT, nil
 }
 
-func putOntIDToken(native *native.NativeService, contractAddr, ontID []byte, tokens *roleTokens) error {
-	key, _ := concatOntIDTokenKey(native, contractAddr, ontID)
+func putOntIDToken(native *native.NativeService, contractAddr common.Address, ontID []byte, tokens *roleTokens) error {
+	key := concatOntIDTokenKey(native, contractAddr, ontID)
 	bf := new(bytes.Buffer)
 	err := tokens.Serialize(bf)
 	if err != nil {
@@ -151,18 +143,17 @@ func putOntIDToken(native *native.NativeService, contractAddr, ontID []byte, tok
 }
 
 //type(this.contractAddr.DelegateStatus.ontID)
-func concatDelegateStatusKey(native *native.NativeService, contractAddr, ontID []byte) ([]byte, error) {
+func concatDelegateStatusKey(native *native.NativeService, contractAddr common.Address, ontID []byte) []byte {
 	this := native.ContextRef.CurrentContext().ContractAddress
-	key, err := packKeys(this, [][]byte{contractAddr, PreDelegateStatus, ontID})
+	key := append(this[:], contractAddr[:]...)
+	key = append(key, PreDelegateStatus...)
+	key = append(key, ontID...)
 
-	return key, err
+	return key
 }
 
-func getDelegateStatus(native *native.NativeService, contractAddr, ontID []byte) (*Status, error) {
-	key, err := concatDelegateStatusKey(native, contractAddr, ontID)
-	if err != nil {
-		return nil, err
-	}
+func getDelegateStatus(native *native.NativeService, contractAddr common.Address, ontID []byte) (*Status, error) {
+	key := concatDelegateStatusKey(native, contractAddr, ontID)
 	item, err := utils.GetStorageItem(native, key)
 	if err != nil {
 		return nil, err
@@ -179,8 +170,8 @@ func getDelegateStatus(native *native.NativeService, contractAddr, ontID []byte)
 	return status, nil
 }
 
-func putDelegateStatus(native *native.NativeService, contractAddr, ontID []byte, status *Status) error {
-	key, _ := concatDelegateStatusKey(native, contractAddr, ontID)
+func putDelegateStatus(native *native.NativeService, contractAddr common.Address, ontID []byte, status *Status) error {
+	key := concatDelegateStatusKey(native, contractAddr, ontID)
 	bf := new(bytes.Buffer)
 	err := status.Serialize(bf)
 	if err != nil {
@@ -188,30 +179,6 @@ func putDelegateStatus(native *native.NativeService, contractAddr, ontID []byte,
 	}
 	utils.PutBytes(native, key, bf.Bytes())
 	return nil
-}
-
-/*
- * pack data to be used as a key in the kv storage
- * key := field || ser_items[1] || ... || ser_items[n]
- */
-func packKeys(field common.Address, items [][]byte) ([]byte, error) {
-	w := new(bytes.Buffer)
-	for _, item := range items {
-		err := serialization.WriteVarBytes(w, item)
-		if err != nil {
-			return nil, fmt.Errorf("packKeys failed when serialize %x", item)
-		}
-	}
-	key := append(field[:], w.Bytes()...)
-	return key, nil
-}
-
-/*
- * pack data to be used as a key in the kv storage
- * key := field || ser_data
- */
-func packKey(field common.Address, data []byte) ([]byte, error) {
-	return packKeys(field, [][]byte{data})
 }
 
 //remote duplicates in the slice of string
@@ -237,10 +204,6 @@ func pushEvent(native *native.NativeService, s interface{}) {
 	event.ContractAddress = native.ContextRef.CurrentContext().ContractAddress
 	event.States = s
 	native.Notifications = append(native.Notifications, event)
-}
-
-func invokeEvent(native *native.NativeService, fn string, ret bool) {
-	pushEvent(native, []interface{}{fn, ret})
 }
 
 func serializeAddress(w io.Writer, addr common.Address) error {


### PR DESCRIPTION
`verifyToken` function invokes ONT ID contract's `verifySig` function, and the keyNo param should be serialized using utils.WriteVarUint instead of serialization.WriteVarUInt. 