### PR TITLE
NCC-2018-024 Denial-of-Service via Arbitrary Precision Multiplication

### DIFF
--- a/common/bigint.go
+++ b/common/bigint.go
@@ -28,11 +28,10 @@ func bytesReverse(u []byte) []byte {
 }
 
 func BigIntToNeoBytes(data *big.Int) []byte {
-	if data.Int64() == 0 {
+	bs := data.Bytes()
+	if len(bs) == 0 {
 		return []byte{}
 	}
-
-	bs := data.Bytes()
 	b := bs[0]
 	if data.Sign() < 0 {
 		for i, b := range bs {

--- a/vm/neovm/types/common.go
+++ b/vm/neovm/types/common.go
@@ -30,11 +30,10 @@ func bytesReverse(u []byte) []byte {
 }
 
 func BigIntToBytes(data *big.Int) []byte {
-	if data.Int64() == 0 {
+	bs := data.Bytes()
+	if len(bs) == 0 {
 		return []byte{}
 	}
-
-	bs := data.Bytes()
 	b := bs[0]
 	if data.Sign() < 0 {
 		for i, b := range bs {


### PR DESCRIPTION
bug caused by calling `big.Int.Int64` function, when the value
greater than int64, 0 will be returned.

Signed-off-by: laizy <laizhichao@onchain.com>