### PR TITLE
use Uint256 instead of [32]byte in p2p

### DIFF
--- a/p2pserver/common/p2p_common.go
+++ b/p2pserver/common/p2p_common.go
@@ -43,7 +43,6 @@ const (
 	MSG_CMD_LEN      = 12               //msg type length in byte
 	CMD_OFFSET       = 4                //cmd type offet in msg hdr
 	CHECKSUM_LEN     = 4                //checksum length in byte
-	HASH_LEN         = 32               // hash length in byte
 	MSG_HDR_LEN      = 24               //msg hdr length in byte
 	MAX_BLK_HDR_CNT  = 500              //hdr count once when sync header
 	MAX_INV_HDR_CNT  = 500              //inventory count once when req inv

--- a/p2pserver/link/link.go
+++ b/p2pserver/link/link.go
@@ -159,6 +159,7 @@ func (this *Link) Tx(msg types.Message) error {
 	err := types.WriteMessage(buf, msg)
 	if err != nil {
 		log.Error("error serialize messge ", err.Error())
+		return err
 	}
 
 	payload := buf.Bytes()

--- a/p2pserver/message/msg_pack/msg_pack.go
+++ b/p2pserver/message/msg_pack/msg_pack.go
@@ -65,8 +65,7 @@ func NewHeaders(headers []*ct.Header) mt.Message {
 func NewHeadersReq(curHdrHash common.Uint256) mt.Message {
 	var h mt.HeadersReq
 	h.Len = 1
-	buf := curHdrHash
-	copy(h.HashEnd[:], buf[:])
+	h.HashEnd = curHdrHash
 
 	return &h
 }

--- a/p2pserver/message/types/block_headers_req.go
+++ b/p2pserver/message/types/block_headers_req.go
@@ -23,14 +23,15 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	comm "github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/errors"
 	"github.com/ontio/ontology/p2pserver/common"
 )
 
 type HeadersReq struct {
 	Len       uint8
-	HashStart [common.HASH_LEN]byte
-	HashEnd   [common.HASH_LEN]byte
+	HashStart comm.Uint256
+	HashEnd   comm.Uint256
 }
 
 //Serialize message payload

--- a/p2pserver/message/types/block_headers_req_test.go
+++ b/p2pserver/message/types/block_headers_req_test.go
@@ -28,8 +28,7 @@ func TestBlkHdrReqSerializationDeserialization(t *testing.T) {
 	msg.Len = 1
 
 	hashstr := "8932da73f52b1e22f30c609988ed1f693b6144f74fed9a2a20869afa7abfdf5e"
-	bhash, _ := cm.HexToBytes(hashstr)
-	copy(msg.HashStart[:], bhash)
+	msg.HashStart, _ = cm.Uint256FromHexString(hashstr)
 
 	MessageTest(t, &msg)
 }

--- a/p2pserver/message/types/blocks_req.go
+++ b/p2pserver/message/types/blocks_req.go
@@ -23,14 +23,15 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	comm "github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/errors"
 	"github.com/ontio/ontology/p2pserver/common"
 )
 
 type BlocksReq struct {
 	HeaderHashCount uint8
-	HashStart       [common.HASH_LEN]byte
-	HashStop        [common.HASH_LEN]byte
+	HashStart       comm.Uint256
+	HashStop        comm.Uint256
 }
 
 //Serialize message payload

--- a/p2pserver/message/types/blocks_req_test.go
+++ b/p2pserver/message/types/blocks_req_test.go
@@ -28,8 +28,7 @@ func TestBlkReqSerializationDeserialization(t *testing.T) {
 	msg.HeaderHashCount = 1
 
 	hashstr := "8932da73f52b1e22f30c609988ed1f693b6144f74fed9a2a20869afa7abfdf5e"
-	bhash, _ := cm.HexToBytes(hashstr)
-	copy(msg.HashStart[:], bhash)
+	msg.HashStart, _ = cm.Uint256FromHexString(hashstr)
 
 	MessageTest(t, &msg)
 }

--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -80,14 +80,12 @@ func HeadersReqHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID,
 
 	headersReq := data.Payload.(*msgTypes.HeadersReq)
 
-	var startHash [msgCommon.HASH_LEN]byte
-	var stopHash [msgCommon.HASH_LEN]byte
-	startHash = headersReq.HashStart
-	stopHash = headersReq.HashEnd
+	startHash := headersReq.HashStart
+	stopHash := headersReq.HashEnd
 
 	headers, err := GetHeadersFromHash(startHash, stopHash)
 	if err != nil {
-		log.Errorf("get headers in HeadersReqHandle error: %s,startHash:%x,stopHash:%x", err.Error(), common.ToArrayReverse(startHash[:]), common.ToArrayReverse(stopHash[:]))
+		log.Errorf("get headers in HeadersReqHandle error: %s,startHash:%s,stopHash:%s", err.Error(), startHash.ToHexString(), stopHash.ToHexString())
 		return
 	}
 	remotePeer := p2p.GetPeer(data.Id)
@@ -636,13 +634,12 @@ func DisconnectHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID,
 //get blk hdrs from starthash to stophash
 func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]*types.Header, error) {
 	var count uint32 = 0
-	var empty [msgCommon.HASH_LEN]byte
 	headers := []*types.Header{}
 	var startHeight uint32
 	var stopHeight uint32
 	curHeight := ledger.DefLedger.GetCurrentHeaderHeight()
-	if startHash == empty {
-		if stopHash == empty {
+	if startHash == common.UINT256_EMPTY {
+		if stopHash == common.UINT256_EMPTY {
 			if curHeight > msgCommon.MAX_BLK_HDR_CNT {
 				count = msgCommon.MAX_BLK_HDR_CNT
 			} else {
@@ -665,7 +662,7 @@ func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]*t
 			return nil, err
 		}
 		startHeight = bkStart.Height
-		if stopHash != empty {
+		if stopHash != common.UINT256_EMPTY {
 			bkStop, err := ledger.DefLedger.GetHeaderByHash(stopHash)
 			if err != nil || bkStop == nil {
 				return nil, err


### PR DESCRIPTION
1. change [32]byte to Uint256 in BlocksReq, HeadersReq
2. fix forgotten error return in Tx

compatibility: internal refactoring

Signed-off-by: laizy <laizhichao@onchain.com>