### PR TITLE
ONT-1069 ontology-crypto update to v1.0.1

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/ontio/ontology-eventbus
   version: v0.9.1
 - package: github.com/ontio/ontology-crypto
-  version: v0.9
+  version: v1.0.1
 - package: github.com/howeyc/gopass
 - package: github.com/gorilla/websocket
   version: v1.2.0


### PR DESCRIPTION
ontology-crypto fixed a bug of deserializing signature and added support for various key types in VRF.