### PR TITLE
ONT-1091 optimize block sync

### DIFF
--- a/p2pserver/actor/server/actor.go
+++ b/p2pserver/actor/server/actor.go
@@ -91,9 +91,9 @@ func (this *P2PActor) Receive(ctx actor.Context) {
 	case *common.RemovePeerID:
 		this.server.OnDelNode(msg.ID)
 	case *common.AppendHeaders:
-		this.server.OnHeaderReceive(msg.Headers)
+		this.server.OnHeaderReceive(msg.FromID, msg.Headers)
 	case *common.AppendBlock:
-		this.server.OnBlockReceive(msg.Block)
+		this.server.OnBlockReceive(msg.FromID, msg.Block)
 	default:
 		err := this.server.Xmit(ctx.Message())
 		if nil != err {

--- a/p2pserver/actor/server/actor.go
+++ b/p2pserver/actor/server/actor.go
@@ -93,7 +93,7 @@ func (this *P2PActor) Receive(ctx actor.Context) {
 	case *common.AppendHeaders:
 		this.server.OnHeaderReceive(msg.FromID, msg.Headers)
 	case *common.AppendBlock:
-		this.server.OnBlockReceive(msg.FromID, msg.Block)
+		this.server.OnBlockReceive(msg.FromID, msg.BlockSize, msg.Block)
 	default:
 		err := this.server.Xmit(ctx.Message())
 		if nil != err {

--- a/p2pserver/common/p2p_common.go
+++ b/p2pserver/common/p2p_common.go
@@ -144,8 +144,9 @@ type AppendHeaders struct {
 }
 
 type AppendBlock struct {
-	FromID uint64       // The peer id
-	Block  *types.Block // Block to be added to the ledger
+	FromID    uint64       // The peer id
+	BlockSize uint32       // Block size
+	Block     *types.Block // Block to be added to the ledger
 }
 
 //ParseIPAddr return ip address

--- a/p2pserver/common/p2p_common.go
+++ b/p2pserver/common/p2p_common.go
@@ -33,9 +33,12 @@ const (
 
 //link and concurrent const
 const (
-	PER_SEND_LEN   = 1024 * 256 //byte len per conn write
-	MAX_BUF_LEN    = 1024 * 256 //the maximum buffer to receive message
-	WRITE_DEADLINE = 5          //deadline of conn write
+	PER_SEND_LEN        = 1024 * 256 //byte len per conn write
+	MAX_BUF_LEN         = 1024 * 256 //the maximum buffer to receive message
+	WRITE_DEADLINE      = 5          //deadline of conn write
+	REQ_INTERVAL        = 3          //single request max interval in second
+	MAX_REQ_RECORD_SIZE = 1000       //the maximum request record size
+	MAX_RESP_CACHE_SIZE = 50         //the maximum response cache
 )
 
 //msg cmd const
@@ -60,7 +63,7 @@ const (
 //info update const
 const (
 	PROTOCOL_VERSION      = 0     //protocol version
-	UPDATE_RATE_PER_BLOCK = 2     //info update rate in one generate block period
+	UPDATE_RATE_PER_BLOCK = 6     //info update rate in one generate block period
 	KEEPALIVE_TIMEOUT     = 15    //contact timeout in sec
 	DIAL_TIMEOUT          = 6     //connect timeout in sec
 	CONN_MONITOR          = 6     //time to retry connect in sec
@@ -136,11 +139,13 @@ type RemovePeerID struct {
 }
 
 type AppendHeaders struct {
+	FromID  uint64          // The peer id
 	Headers []*types.Header // Headers to be added to the ledger
 }
 
 type AppendBlock struct {
-	Block *types.Block // Block to be added to the ledger
+	FromID uint64       // The peer id
+	Block  *types.Block // Block to be added to the ledger
 }
 
 //ParseIPAddr return ip address

--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -162,8 +162,9 @@ func BlockHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, args
 	if pid != nil {
 		var block = data.Payload.(*msgTypes.Block)
 		input := &msgCommon.AppendBlock{
-			FromID: data.Id,
-			Block:  &block.Blk,
+			FromID:    data.Id,
+			BlockSize: data.PayloadSize,
+			Block:     &block.Blk,
 		}
 		pid.Tell(input)
 	}

--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -143,6 +143,7 @@ func BlkHeaderHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, 
 	if pid != nil {
 		var blkHeader = data.Payload.(*msgTypes.BlkHeader)
 		input := &msgCommon.AppendHeaders{
+			FromID:  data.Id,
 			Headers: blkHeader.BlkHdr,
 		}
 		pid.Tell(input)
@@ -156,7 +157,8 @@ func BlockHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, args
 	if pid != nil {
 		var block = data.Payload.(*msgTypes.Block)
 		input := &msgCommon.AppendBlock{
-			Block: &block.Blk,
+			FromID: data.Id,
+			Block:  &block.Blk,
 		}
 		pid.Tell(input)
 	}

--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -206,8 +206,8 @@ func (this *P2PServer) OnHeaderReceive(fromID uint64, headers []*types.Header) {
 }
 
 // OnBlockReceive adds the block from network
-func (this *P2PServer) OnBlockReceive(fromID uint64, block *types.Block) {
-	this.blockSync.OnBlockReceive(fromID, block)
+func (this *P2PServer) OnBlockReceive(fromID uint64, blockSize uint32, block *types.Block) {
+	this.blockSync.OnBlockReceive(fromID, blockSize, block)
 }
 
 // Todo: remove it if no use

--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -201,13 +201,13 @@ func (this *P2PServer) OnDelNode(id uint64) {
 }
 
 // OnHeaderReceive adds the header list from network
-func (this *P2PServer) OnHeaderReceive(headers []*types.Header) {
-	this.blockSync.OnHeaderReceive(headers)
+func (this *P2PServer) OnHeaderReceive(fromID uint64, headers []*types.Header) {
+	this.blockSync.OnHeaderReceive(fromID, headers)
 }
 
 // OnBlockReceive adds the block from network
-func (this *P2PServer) OnBlockReceive(block *types.Block) {
-	this.blockSync.OnBlockReceive(block)
+func (this *P2PServer) OnBlockReceive(fromID uint64, block *types.Block) {
+	this.blockSync.OnBlockReceive(fromID, block)
 }
 
 // Todo: remove it if no use


### PR DESCRIPTION
1. record peer's network status, timeout/error times
2. remove the error node from the list
3. request more nodes for min height block
4. combine same get data request 
5. add block cache to avoid ledger operation frequently
6. adjust send ping message period

Signed-off-by: chenzhijie <chenzhijie@onchain.com>