### PR TITLE
implement zero copy source/sink

### DIFF
--- a/common/zero_copy_sink.go
+++ b/common/zero_copy_sink.go
@@ -1,0 +1,152 @@
+package common
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+type ZeroCopySink struct {
+	buf []byte
+}
+
+// tryGrowByReslice is a inlineable version of grow for the fast-case where the
+// internal buffer only needs to be resliced.
+// It returns the index where bytes should be written and whether it succeeded.
+func (self *ZeroCopySink) tryGrowByReslice(n int) (int, bool) {
+	if l := len(self.buf); n <= cap(self.buf)-l {
+		self.buf = self.buf[:l+n]
+		return l, true
+	}
+	return 0, false
+}
+
+const maxInt = int(^uint(0) >> 1)
+
+// grow grows the buffer to guarantee space for n more bytes.
+// It returns the index where bytes should be written.
+// If the buffer can't grow it will panic with ErrTooLarge.
+func (self *ZeroCopySink) grow(n int) int {
+	// Try to grow by means of a reslice.
+	if i, ok := self.tryGrowByReslice(n); ok {
+		return i
+	}
+
+	l := len(self.buf)
+	c := cap(self.buf)
+	if c > maxInt-c-n {
+		panic(ErrTooLarge)
+	}
+	// Not enough space anywhere, we need to allocate.
+	buf := makeSlice(2*c + n)
+	copy(buf, self.buf)
+	self.buf = buf[:l+n]
+	return l
+}
+
+func (self *ZeroCopySink) WriteBytes(p []byte) {
+	data := self.NextBytes(uint64(len(p)))
+	copy(data, p)
+}
+
+func (self *ZeroCopySink) Size() uint64 { return uint64(len(self.buf)) }
+
+func (self *ZeroCopySink) NextBytes(n uint64) (data []byte) {
+	m, ok := self.tryGrowByReslice(int(n))
+	if !ok {
+		m = self.grow(int(n))
+	}
+	data = self.buf[m:]
+	return
+}
+
+// Backs up a number of bytes, so that the next call to NextXXX() returns data again
+// that was already returned by the last call to NextXXX().
+func (self *ZeroCopySink) BackUp(n uint64) {
+	l := len(self.buf) - int(n)
+	self.buf = self.buf[:l]
+}
+
+func (self *ZeroCopySink) WriteUint8(data uint8) {
+	buf := self.NextBytes(1)
+	buf[0] = data
+}
+
+func (self *ZeroCopySink) WriteByte(c byte) {
+	self.WriteUint8(c)
+}
+
+func (self *ZeroCopySink) WriteUint16(data uint16) {
+	buf := self.NextBytes(2)
+	binary.LittleEndian.PutUint16(buf, data)
+}
+
+func (self *ZeroCopySink) WriteUint32(data uint32) {
+	buf := self.NextBytes(4)
+	binary.LittleEndian.PutUint32(buf, data)
+}
+
+func (self *ZeroCopySink) WriteUint64(data uint64) {
+	buf := self.NextBytes(8)
+	binary.LittleEndian.PutUint64(buf, data)
+}
+
+func (self *ZeroCopySink) WriteInt16(data int16) {
+	self.WriteUint16(uint16(data))
+}
+
+func (self *ZeroCopySink) WriteVarBytes(data []byte) (size uint64) {
+	l := uint64(len(data))
+	size = self.WriteVarUint(l) + l
+
+	self.WriteBytes(data)
+	return
+}
+
+func (self *ZeroCopySink) WriteString(data string) (size uint64) {
+	return self.WriteVarBytes([]byte(data))
+}
+
+func (self *ZeroCopySink) WriteVarUint(data uint64) (size uint64) {
+	buf := self.NextBytes(9)
+	if data < 0xFD {
+		buf[0] = uint8(data)
+		size = 1
+	} else if data <= 0xFFFF {
+		buf[0] = 0xFD
+		binary.LittleEndian.PutUint16(buf[1:], uint16(data))
+		size = 3
+	} else if data <= 0xFFFFFFFF {
+		buf[0] = 0xFE
+		binary.LittleEndian.PutUint32(buf[1:], uint32(data))
+		size = 5
+	} else {
+		buf[0] = 0xFF
+		binary.LittleEndian.PutUint64(buf[1:], uint64(data))
+		size = 9
+	}
+
+	self.BackUp(9 - size)
+	return
+}
+
+// NewReader returns a new ZeroCopySink reading from b.
+func NewZeroCopySink(b []byte) *ZeroCopySink { return &ZeroCopySink{b} }
+
+func (self *ZeroCopySink) Bytes() []byte { return self.buf }
+
+func (self *ZeroCopySink) Reset() { self.buf = self.buf[:0] }
+
+var ErrTooLarge = errors.New("bytes.Buffer: too large")
+
+// makeSlice allocates a slice of size n. If the allocation fails, it panics
+// with ErrTooLarge.
+func makeSlice(n int) []byte {
+	// If the make fails, give a known error.
+	defer func() {
+		if recover() != nil {
+			panic(bytes.ErrTooLarge)
+		}
+	}()
+	return make([]byte, n)
+}

--- a/common/zero_copy_sink.go
+++ b/common/zero_copy_sink.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package common
 
 import (
@@ -74,6 +91,14 @@ func (self *ZeroCopySink) WriteUint8(data uint8) {
 
 func (self *ZeroCopySink) WriteByte(c byte) {
 	self.WriteUint8(c)
+}
+
+func (self *ZeroCopySink) WriteBool(data bool) {
+	if data {
+		self.WriteByte(1)
+	} else {
+		self.WriteByte(0)
+	}
 }
 
 func (self *ZeroCopySink) WriteUint16(data uint16) {

--- a/common/zero_copy_sink.go
+++ b/common/zero_copy_sink.go
@@ -116,6 +116,14 @@ func (self *ZeroCopySink) WriteUint64(data uint64) {
 	binary.LittleEndian.PutUint64(buf, data)
 }
 
+func (self *ZeroCopySink) WriteInt64(data int64) {
+	self.WriteUint64(uint64(data))
+}
+
+func (self *ZeroCopySink) WriteInt32(data int32) {
+	self.WriteUint32(uint32(data))
+}
+
 func (self *ZeroCopySink) WriteInt16(data int16) {
 	self.WriteUint16(uint16(data))
 }
@@ -130,6 +138,14 @@ func (self *ZeroCopySink) WriteVarBytes(data []byte) (size uint64) {
 
 func (self *ZeroCopySink) WriteString(data string) (size uint64) {
 	return self.WriteVarBytes([]byte(data))
+}
+
+func (self *ZeroCopySink) WriteAddress(addr Address) {
+	self.WriteBytes(addr[:])
+}
+
+func (self *ZeroCopySink) WriteHash(hash Uint256) {
+	self.WriteBytes(hash[:])
 }
 
 func (self *ZeroCopySink) WriteVarUint(data uint64) (size uint64) {

--- a/common/zero_copy_sink_test.go
+++ b/common/zero_copy_sink_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package common
 
 import (
@@ -5,7 +22,43 @@ import (
 
 	"bytes"
 	ser "github.com/ontio/ontology/common/serialization"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestSourceSink(t *testing.T) {
+	a3 := uint8(100)
+	a4 := uint16(65535)
+	a5 := uint32(4294967295)
+	a6 := uint64(18446744073709551615)
+	a7 := uint64(18446744073709551615)
+	a8 := []byte{10, 11, 12}
+	a9 := "hello onchain."
+	sink := NewZeroCopySink(nil)
+	sink.WriteByte(a3)
+	sink.WriteUint16(a4)
+	sink.WriteUint32(a5)
+	sink.WriteUint64(a6)
+	sink.WriteVarUint(a7)
+	sink.WriteVarBytes(a8)
+	sink.WriteString(a9)
+
+	source := NewZeroCopySource(sink.Bytes())
+	b3, _ := source.NextByte()
+	assert.Equal(t, a3, b3)
+	b4, _ := source.NextUint16()
+	assert.Equal(t, a4, b4)
+	b5, _ := source.NextUint32()
+	assert.Equal(t, a5, b5)
+	b6, _ := source.NextUint64()
+	assert.Equal(t, a6, b6)
+	b7, _, _, _ := source.NextVarUint()
+	assert.Equal(t, a7, b7)
+	b8, _, _, _ := source.NextVarBytes()
+	assert.Equal(t, a8, b8)
+	b9, _, _, _ := source.NextString()
+	assert.Equal(t, a9, b9)
+
+}
 
 func BenchmarkSerialize(ben *testing.B) {
 	N := 1000

--- a/common/zero_copy_sink_test.go
+++ b/common/zero_copy_sink_test.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"testing"
+
+	"bytes"
+	ser "github.com/ontio/ontology/common/serialization"
+)
+
+func BenchmarkSerialize(ben *testing.B) {
+	N := 1000
+	a3 := uint8(100)
+	a4 := uint16(65535)
+	a5 := uint32(4294967295)
+	a6 := uint64(18446744073709551615)
+	a7 := uint64(18446744073709551615)
+	a8 := []byte{10, 11, 12}
+	a9 := "hello onchain."
+	b := new(bytes.Buffer)
+	for i := 0; i < ben.N; i++ {
+		b.Reset()
+		for j := 0; j < N; j++ {
+			ser.WriteVarUint(b, uint64(a3))
+			ser.WriteVarUint(b, uint64(a4))
+			ser.WriteVarUint(b, uint64(a5))
+			ser.WriteVarUint(b, uint64(a6))
+			ser.WriteVarUint(b, uint64(a7))
+			ser.WriteVarBytes(b, a8)
+			ser.WriteString(b, a9)
+
+			b.WriteByte(20)
+			b.WriteByte(21)
+			b.WriteByte(22)
+		}
+	}
+}
+
+func BenchmarkZeroCopySink(ben *testing.B) {
+	N := 1000
+	a3 := uint8(100)
+	a4 := uint16(65535)
+	a5 := uint32(4294967295)
+	a6 := uint64(18446744073709551615)
+	a7 := uint64(18446744073709551615)
+	a8 := []byte{10, 11, 12}
+	a9 := "hello onchain."
+	sink := NewZeroCopySink(nil)
+	for i := 0; i < ben.N; i++ {
+		sink.Reset()
+		for j := 0; j < N; j++ {
+			sink.WriteVarUint(uint64(a3))
+			sink.WriteVarUint(uint64(a4))
+			sink.WriteVarUint(uint64(a5))
+			sink.WriteVarUint(uint64(a6))
+			sink.WriteVarUint(uint64(a7))
+			sink.WriteVarBytes(a8)
+			sink.WriteString(a9)
+			sink.WriteByte(20)
+			sink.WriteByte(21)
+			sink.WriteByte(22)
+		}
+	}
+
+}

--- a/common/zero_copy_source.go
+++ b/common/zero_copy_source.go
@@ -1,0 +1,160 @@
+package common
+
+import (
+	"encoding/binary"
+)
+
+type ZeroCopySource struct {
+	s   []byte
+	off uint64 // current reading index
+}
+
+// Len returns the number of bytes of the unread portion of the
+// slice.
+func (self *ZeroCopySource) Len() uint64 {
+	length := uint64(len(self.s))
+	if self.off >= length {
+		return 0
+	}
+	return length - self.off
+}
+
+func (self *ZeroCopySource) Pos() uint64 {
+	return self.off
+}
+
+// Size returns the original length of the underlying byte slice.
+// Size is the number of bytes available for reading via ReadAt.
+// The returned value is always the same and is not affected by calls
+// to any other method.
+func (self *ZeroCopySource) Size() uint64 { return uint64(len(self.s)) }
+
+// Read implements the io.ZeroCopySource interface.
+func (self *ZeroCopySource) NextBytes(n uint64) (data []byte, eof bool) {
+	m := uint64(len(self.s))
+	end, overflow := SafeAdd(self.off, n)
+	if overflow || end > m{
+		end = m
+		eof = true
+	}
+	data = self.s[self.off:end]
+	self.off = end
+
+	return
+}
+
+func (self *ZeroCopySource) Skip(n uint64) (eof bool) {
+	m := uint64(len(self.s))
+	end, overflow := SafeAdd(self.off, n)
+	if overflow || end > m {
+		end = m
+		eof = true
+	}
+	self.off = end
+
+	return
+}
+
+// ReadByte implements the io.ByteReader interface.
+func (self *ZeroCopySource) NextByte() (data byte, eof bool) {
+	if self.off >= uint64(len(self.s)) {
+		return 0, true
+	}
+
+	b := self.s[self.off]
+	self.off++
+	return b, false
+}
+
+
+// Backs up a number of bytes, so that the next call to NextXXX() returns data again
+// that was already returned by the last call to NextXXX().
+func (self *ZeroCopySource) BackUp(n uint64) {
+	self.off -= n
+}
+
+func (self *ZeroCopySource) NextUint16() (data uint16, eof bool) {
+	var buf []byte
+	buf, eof = self.NextBytes(2)
+	if eof {
+		return
+	}
+
+	return binary.LittleEndian.Uint16(buf), eof
+}
+
+func (self *ZeroCopySource) NextUint32() (data uint32, eof bool) {
+	var buf []byte
+	buf, eof = self.NextBytes(4)
+	if eof {
+		return
+	}
+
+	return binary.LittleEndian.Uint32(buf), eof
+}
+
+func (self *ZeroCopySource) NextUint64() (data uint64, eof bool) {
+	var buf []byte
+	buf, eof = self.NextBytes(8)
+	if eof {
+		return
+	}
+
+	return binary.LittleEndian.Uint64(buf), eof
+}
+
+func (self *ZeroCopySource) NextInt16() (data int16, eof bool) {
+	var val uint16
+	val, eof = self.NextUint16()
+	return int16(val), eof
+
+}
+
+func (self *ZeroCopySource) NextVarBytes() (data []byte, size uint64, eof bool) {
+	var count uint64
+	count, size, eof = self.NextVarUint()
+
+	data, eof = self.NextBytes(count)
+
+	return data, size + count, eof
+}
+
+func (self *ZeroCopySource) NextVarUint() (data uint64, size uint64, eof bool) {
+	var fb byte
+	fb, eof = self.NextByte()
+	if eof {
+		return
+	}
+
+	switch fb {
+	case 0xFD:
+		val, e := self.NextUint16()
+		if e {
+			return
+		}
+		data = uint64(val)
+		size = 3
+	case 0xFE:
+		val, e := self.NextUint32()
+		if e {
+			return
+		}
+		data = uint64(val)
+		size = 5
+	case 0xFF:
+		val, e := self.NextUint64()
+		if e {
+			return
+		}
+		data = uint64(val)
+		size = 9
+	default:
+		data = uint64(fb)
+		size = 1
+	}
+
+	return
+}
+
+// NewReader returns a new ZeroCopySource reading from b.
+func NewZeroCopySource(b []byte) *ZeroCopySource { return &ZeroCopySource{b, 0} }

--- a/common/zero_copy_source_test.go
+++ b/common/zero_copy_source_test.go
@@ -1,19 +1,37 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package common
 
 import (
-	"testing"
+	"bytes"
 	"crypto/rand"
+	"github.com/ontio/ontology/common/serialization"
+	"testing"
 )
-
 
 func BenchmarkZeroCopySource(b *testing.B) {
 	const N = 12000
 	buf := make([]byte, N)
 	rand.Read(buf)
 
-	for i:=0; i< b.N; i++ {
+	for i := 0; i < b.N; i++ {
 		source := NewZeroCopySource(buf)
-		for j := 0; j < N/100; j++  {
+		for j := 0; j < N/100; j++ {
 			source.NextUint16()
 			source.NextByte()
 			source.NextUint64()
@@ -24,3 +42,20 @@ func BenchmarkZeroCopySource(b *testing.B) {
 
 }
 
+func BenchmarkDerserialize(b *testing.B) {
+	const N = 12000
+	buf := make([]byte, N)
+	rand.Read(buf)
+
+	for i := 0; i < b.N; i++ {
+		reader := bytes.NewBuffer(buf)
+		for j := 0; j < N/100; j++ {
+			serialization.ReadUint16(reader)
+			serialization.ReadByte(reader)
+			serialization.ReadUint64(reader)
+			serialization.ReadVarUint(reader, 0)
+			serialization.ReadBytes(reader, 20)
+		}
+	}
+
+}

--- a/common/zero_copy_source_test.go
+++ b/common/zero_copy_source_test.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"testing"
+	"crypto/rand"
+)
+
+
+func BenchmarkZeroCopySource(b *testing.B) {
+	const N = 12000
+	buf := make([]byte, N)
+	rand.Read(buf)
+
+	for i:=0; i< b.N; i++ {
+		source := NewZeroCopySource(buf)
+		for j := 0; j < N/100; j++  {
+			source.NextUint16()
+			source.NextByte()
+			source.NextUint64()
+			source.NextVarUint()
+			source.NextBytes(20)
+		}
+	}
+
+}
+

--- a/vm/neovm/utils/vm_reader.go
+++ b/vm/neovm/utils/vm_reader.go
@@ -35,10 +35,6 @@ func NewVmReader(b []byte) *VmReader {
 	return &vmreader
 }
 
-func (r *VmReader) Reader() *bytes.Reader {
-	return r.reader
-}
-
 func (r *VmReader) ReadByte() (byte, error) {
 	byte, err := r.reader.ReadByte()
 	return byte, err


### PR DESCRIPTION
the current serialization has very poor performance caused by too many memory allocation.