### PR TITLE
modify for support array state param for transfer

### DIFF
--- a/smartcontract/service/native/ont/states.go
+++ b/smartcontract/service/native/ont/states.go
@@ -85,7 +85,7 @@ func (this *State) Deserialize(r io.Reader) error {
 		//for array case, the first element is count
 		//so from is the second element
 		this.From, err = utils.ReadAddress(r)
-		if err != nil{
+		if err != nil {
 			return fmt.Errorf("[State] deserialize from error:%v", err)
 		}
 	}

--- a/smartcontract/service/native/ont/states.go
+++ b/smartcontract/service/native/ont/states.go
@@ -82,7 +82,12 @@ func (this *State) Deserialize(r io.Reader) error {
 	var err error
 	this.From, err = utils.ReadAddress(r)
 	if err != nil {
-		return fmt.Errorf("[State] deserialize from error:%v", err)
+		//for array case, the first element is count
+		//so from is the second element
+		this.From, err = utils.ReadAddress(r)
+		if err != nil{
+			return fmt.Errorf("[State] deserialize from error:%v", err)
+		}
 	}
 	this.To, err = utils.ReadAddress(r)
 	if err != nil {


### PR DESCRIPTION
since python compiler doesn't support Struct, we need to support array for transfer