### PR TITLE
revert "switch to Euclidean modulus (#677)"

### DIFF
--- a/vm/neovm/common.go
+++ b/vm/neovm/common.go
@@ -119,9 +119,9 @@ func BigIntZip(ints1 *big.Int, ints2 *big.Int, op OpCode) *big.Int {
 	case MUL:
 		nb.Mul(ints1, ints2)
 	case DIV:
-		nb.Div(ints1, ints2)
+		nb.Quo(ints1, ints2)
 	case MOD:
-		nb.Mod(ints1, ints2)
+		nb.Rem(ints1, ints2)
 	case SHL:
 		nb.Lsh(ints1, uint(ints2.Int64()))
 	case SHR:


### PR DESCRIPTION
revert to be consistent with golang, and handle negative mod value in contract