### PR TITLE
Fix Committer skipped broadcasting commit msg

### DIFF
--- a/consensus/vbft/service.go
+++ b/consensus/vbft/service.go
@@ -1297,6 +1297,13 @@ func (self *Server) processMsgEvent() error {
 						return nil
 					}
 
+					if self.isCommitter(msgBlkNum, self.Index) {
+						// make sure committer broadcasting his commit msg
+						if err := self.makeCommitment(proposal, msgBlkNum, forEmpty); err != nil {
+							log.Errorf("server %d consensused %d, committer broadcast commit msg: %s", self.Index, msgBlkNum, err)
+						}
+					}
+
 					// stop commit timer
 					if err := self.timer.CancelCommitMsgTimer(msgBlkNum); err != nil {
 						log.Errorf("failed to cancel commit timer, blockNum: %d, err: %s", msgBlkNum, err)


### PR DESCRIPTION
In some case, consensus could be reached before one committer broadcasted
his commit msg. If some other peer is catching up, all commit msgs are
useful to help delayed peers catch up.  In the fix, committer always
broadcast his commit msg.