### PR TITLE
fix syncing stopped when network failed

### DIFF
--- a/consensus/vbft/block_pool.go
+++ b/consensus/vbft/block_pool.go
@@ -524,7 +524,9 @@ func (pool *BlockPool) commitDone(blkNum uint32, C uint32, N uint32) (uint32, bo
 					endorseCnt[sig.EndorsedProposer] += 1
 					if endorseCnt[sig.EndorsedProposer] > C {
 						proposer = sig.EndorsedProposer
-						forEmpty = emptyCnt > C
+						if !forEmpty {
+							forEmpty = emptyCnt > C
+						}
 						break
 					}
 				}

--- a/consensus/vbft/state_mgmt.go
+++ b/consensus/vbft/state_mgmt.go
@@ -463,6 +463,7 @@ func (self *StateMgr) canFastForward(targetBlkNum uint32) bool {
 	C := int(self.server.config.C)
 	// one block less than targetBlkNum is also acceptable for fastforward
 	for blkNum := self.server.GetCurrentBlockNo(); blkNum < targetBlkNum; blkNum++ {
+		// check if pending messages for targetBlkNum reached consensus
 		commitMsgs := make([]*blockCommitMsg, 0)
 		for _, msg := range self.server.msgPool.GetCommitMsgs(blkNum) {
 			if c := msg.(*blockCommitMsg); c != nil {
@@ -475,6 +476,7 @@ func (self *StateMgr) canFastForward(targetBlkNum uint32) bool {
 				self.server.Index, len(commitMsgs), blkNum)
 			return false
 		}
+		// check if the proposal message is available
 		foundProposal := false
 		for _, msg := range self.server.msgPool.GetProposalMsgs(blkNum) {
 			if p := msg.(*blockProposalMsg); p != nil && p.Block.getProposer() == proposer {


### PR DESCRIPTION
syncing failed to catch up when network recovered from partitioned.
when network failed, syncer failed to retry.
In the fix, state-mgr compares maxCommitted with syncer target blocknum.  If syncer failed, state-mgr will restart the syncer.