### PR TITLE
show git commit hash in version name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOFMT=gofmt
 GC=go build
-VERSION := $(shell git describe --abbrev=4 --always --tags)
+VERSION := $(shell git describe --always --tags --long)
 BUILD_NODE_PAR = -ldflags "-X github.com/ontio/ontology/common/config.Version=$(VERSION)" #-race
 
 ARCH=$(shell uname -m)


### PR DESCRIPTION
original format: v1.6.0
modified format: v1.6.0-0-ge46e6ce