### PR TITLE
add golang.org/x/net to glide.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ $ cd $GOPATH/src/github.com/ontio/ontology
 $ glide install
 ```
 
+If necessary, update dependent third party packages with glide.
+
+```
+$ cd $GOPATH/src/github.com/ontio/ontology
+$ glide update
+```
+
 Build the source code with make.
 
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -81,6 +81,13 @@ $ cd $GOPATH/src/github.com/ontio/ontology
 $ glide install
 ````
 
+如果项目有新的第三方依赖包，使用glide更新依赖库
+
+````shell
+$ cd $GOPATH/src/github.com/ontio/ontology
+$ glide update
+````
+
 用make编译源码
 
 ```shell

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,5 +32,7 @@ import:
   repo: https://github.com/golang/sys.git
   subpackages:
   - unix
+- package: golang.org/x/net
+  repo: https://github.com/golang/net.git
 ignore:
   - golang.org/x/sys/unix


### PR DESCRIPTION
golang.org/x/net is dependent by http module, 

1. add it to glide.yaml
2. update README
