### PR TITLE
update description of ReservedPeersOnlyFlag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -104,7 +104,7 @@ var (
 	//P2P setting
 	ReservedPeersOnlyFlag = cli.BoolFlag{
 		Name:  "reserved-only",
-		Usage: "Connect reserved peers `<address>` only",
+		Usage: "Connect reserved peers only. Reserved peers are configured with --reserved-file.",
 	}
 	ReservedPeersFileFlag = cli.StringFlag{
 		Name:  "reserved-file",


### PR DESCRIPTION
--reserved-only flag does not accept "address".  
Addresses of reserved peers should be configured with --reserved-file.