### PR TITLE
improve broadcast performance

### DIFF
--- a/common/uint256.go
+++ b/common/uint256.go
@@ -24,7 +24,12 @@ import (
 	"io"
 )
 
-const UINT256_SIZE = 32
+const (
+	UINT16_SIZE  = 2
+	UINT32_SIZE  = 4
+	UINT64_SIZE  = 8
+	UINT256_SIZE = 32
+)
 
 type Uint256 [UINT256_SIZE]byte
 

--- a/common/zero_copy_source.go
+++ b/common/zero_copy_source.go
@@ -115,7 +115,7 @@ func (self *ZeroCopySource) BackUp(n uint64) {
 
 func (self *ZeroCopySource) NextUint16() (data uint16, eof bool) {
 	var buf []byte
-	buf, eof = self.NextBytes(2)
+	buf, eof = self.NextBytes(UINT16_SIZE)
 	if eof {
 		return
 	}
@@ -125,7 +125,7 @@ func (self *ZeroCopySource) NextUint16() (data uint16, eof bool) {
 
 func (self *ZeroCopySource) NextUint32() (data uint32, eof bool) {
 	var buf []byte
-	buf, eof = self.NextBytes(4)
+	buf, eof = self.NextBytes(UINT32_SIZE)
 	if eof {
 		return
 	}
@@ -135,7 +135,7 @@ func (self *ZeroCopySource) NextUint32() (data uint32, eof bool) {
 
 func (self *ZeroCopySource) NextUint64() (data uint64, eof bool) {
 	var buf []byte
-	buf, eof = self.NextBytes(8)
+	buf, eof = self.NextBytes(UINT64_SIZE)
 	if eof {
 		return
 	}

--- a/p2pserver/link/link.go
+++ b/p2pserver/link/link.go
@@ -25,7 +25,6 @@ import (
 	"net"
 	"time"
 
-	comm "github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/common/log"
 	"github.com/ontio/ontology/p2pserver/common"
 	"github.com/ontio/ontology/p2pserver/message/types"
@@ -166,20 +165,12 @@ func (this *Link) CloseConn() {
 	}
 }
 
-func (this *Link) Tx(msg types.Message) error {
+func (this *Link) Tx(msgType string, payload []byte) error {
 	conn := this.conn
 	if conn == nil {
 		return errors.New("[p2p]tx link invalid")
 	}
 
-	sink := comm.NewZeroCopySink(nil)
-	err := types.WriteMessage(sink, msg)
-	if err != nil {
-		log.Debugf("[p2p]error serialize messge ", err.Error())
-		return err
-	}
-
-	payload := sink.Bytes()
 	nByteCnt := len(payload)
 	log.Tracef("[p2p]TX buf length: %d\n", nByteCnt)
 
@@ -188,7 +179,7 @@ func (this *Link) Tx(msg types.Message) error {
 		nCount = 1
 	}
 	conn.SetWriteDeadline(time.Now().Add(time.Duration(nCount*common.WRITE_DEADLINE) * time.Second))
-	_, err = conn.Write(payload)
+	_, err := conn.Write(payload)
 	if err != nil {
 		log.Infof("[p2p]error sending messge to %s :%s", this.GetAddr(), err.Error())
 		this.disconnectNotify()

--- a/p2pserver/message/types/message.go
+++ b/p2pserver/message/types/message.go
@@ -54,7 +54,7 @@ func readMessageHeader(reader io.Reader) (messageHeader, error) {
 	msgh := messageHeader{}
 	hdrBytes := make([]byte, comm.UINT32_SIZE+common.MSG_CMD_LEN+comm.UINT32_SIZE+common.CHECKSUM_LEN)
 
-	if _, err := reader.Read(hdrBytes); err != nil {
+	if _, err := io.ReadFull(reader, hdrBytes); err != nil {
 		return msgh, err
 	}
 

--- a/p2pserver/message/types/message_test.go
+++ b/p2pserver/message/types/message_test.go
@@ -19,8 +19,12 @@ package types
 
 import (
 	"bytes"
+	"encoding/binary"
+	"io"
 	"testing"
+	"time"
 
+	common2 "github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/p2pserver/common"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,15 +32,56 @@ import (
 func TestMsgHdrSerializationDeserialization(t *testing.T) {
 	hdr := newMessageHeader("hdrtest", 0, common.Checksum(nil))
 
-	buf := bytes.NewBuffer(nil)
-	err := writeMessageHeader(buf, hdr)
-	if err != nil {
-		return
-	}
+	sink := common2.NewZeroCopySink(nil)
+	writeMessageHeaderInto(sink, hdr)
 
-	dehdr, err := readMessageHeader(buf)
+	dehdr, err := readMessageHeader(bytes.NewBuffer(sink.Bytes()))
 	assert.Nil(t, err)
 
 	assert.Equal(t, hdr, dehdr)
 
+}
+
+func readMessageHeader_old(reader io.Reader) (messageHeader, error) {
+	msgh := messageHeader{}
+	err := binary.Read(reader, binary.LittleEndian, &msgh)
+	return msgh, err
+}
+
+func TestMsgHdr2(t *testing.T) {
+	hdr := newMessageHeader("hdrtest1", 20, common.Checksum([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+
+	sink := common2.NewZeroCopySink(nil)
+	writeMessageHeaderInto(sink, hdr)
+
+	hdr1, err := readMessageHeader(bytes.NewBuffer(sink.Bytes()))
+	if err != nil {
+		t.Fatalf("read hdr: %s", err)
+	}
+	if hdr1.Length != hdr.Length ||
+		hdr1.Magic != hdr.Magic ||
+		hdr1.CMD != hdr.CMD ||
+		hdr1.Checksum != hdr1.Checksum {
+		t.Fatalf("invalid hdr1: %v", hdr1)
+	}
+}
+
+func TestMsgHdrDesPerformance(t *testing.T) {
+	hdr := newMessageHeader("hdrtest2", 20, common.Checksum([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+
+	sink := common2.NewZeroCopySink(nil)
+	writeMessageHeaderInto(sink, hdr)
+
+	cnt := 1000000
+	startTime := time.Now()
+	for i := 0; i < cnt; i++ {
+		readMessageHeader(bytes.NewBuffer(sink.Bytes()))
+	}
+	t.Logf("hdr1: time: %v", time.Since(startTime))
+
+	startTime = time.Now()
+	for i := 0; i < cnt; i++ {
+		readMessageHeader_old(bytes.NewBuffer(sink.Bytes()))
+	}
+	t.Logf("hdr1: time: %v", time.Since(startTime))
 }

--- a/p2pserver/net/netserver/netserver.go
+++ b/p2pserver/net/netserver/netserver.go
@@ -247,9 +247,9 @@ func (this *NetServer) GetMsgChan(isConsensus bool) chan *types.MsgPayload {
 func (this *NetServer) Send(p *peer.Peer, msg types.Message, isConsensus bool) error {
 	if p != nil {
 		if config.DefConfig.P2PNode.DualPortSupport == false {
-			return p.SendMsg(msg, false)
+			return p.Send(msg, false)
 		}
-		return p.SendMsg(msg, isConsensus)
+		return p.Send(msg, isConsensus)
 	}
 	log.Warn("[p2p]send to a invalid peer")
 	return errors.New("[p2p]send to a invalid peer")
@@ -340,7 +340,7 @@ func (this *NetServer) Connect(addr string, isConsensus bool) error {
 		remotePeer.SetConsState(common.HAND)
 	}
 	version := msgpack.NewVersion(this, isConsensus, ledger.DefLedger.GetCurrentBlockHeight())
-	err = remotePeer.SendMsg(version, isConsensus)
+	err = remotePeer.Send(version, isConsensus)
 	if err != nil {
 		if !isConsensus {
 			this.RemoveFromOutConnRecord(addr)

--- a/p2pserver/net/netserver/netserver.go
+++ b/p2pserver/net/netserver/netserver.go
@@ -247,9 +247,9 @@ func (this *NetServer) GetMsgChan(isConsensus bool) chan *types.MsgPayload {
 func (this *NetServer) Send(p *peer.Peer, msg types.Message, isConsensus bool) error {
 	if p != nil {
 		if config.DefConfig.P2PNode.DualPortSupport == false {
-			return p.Send(msg, false)
+			return p.SendMsg(msg, false)
 		}
-		return p.Send(msg, isConsensus)
+		return p.SendMsg(msg, isConsensus)
 	}
 	log.Warn("[p2p]send to a invalid peer")
 	return errors.New("[p2p]send to a invalid peer")
@@ -340,7 +340,7 @@ func (this *NetServer) Connect(addr string, isConsensus bool) error {
 		remotePeer.SetConsState(common.HAND)
 	}
 	version := msgpack.NewVersion(this, isConsensus, ledger.DefLedger.GetCurrentBlockHeight())
-	err = remotePeer.Send(version, isConsensus)
+	err = remotePeer.SendMsg(version, isConsensus)
 	if err != nil {
 		if !isConsensus {
 			this.RemoveFromOutConnRecord(addr)

--- a/p2pserver/peer/nbr_peers.go
+++ b/p2pserver/peer/nbr_peers.go
@@ -47,7 +47,7 @@ func (this *NbrPeers) Broadcast(msg types.Message, isConsensus bool) {
 	defer this.RUnlock()
 	for _, node := range this.List {
 		if node.syncState == common.ESTABLISH && node.GetRelay() == true {
-			node.Send(msg.CmdType(), sink.Bytes(), isConsensus)
+			node.SendRaw(msg.CmdType(), sink.Bytes(), isConsensus)
 		}
 	}
 }

--- a/p2pserver/peer/peer.go
+++ b/p2pserver/peer/peer.go
@@ -246,7 +246,7 @@ func (this *Peer) SetConsPort(port uint16) {
 //SendToSync call sync link to send buffer
 func (this *Peer) SendToSync(msgType string, msgPayload []byte) error {
 	if this.SyncLink != nil && this.SyncLink.Valid() {
-		return this.SyncLink.Tx(msgType, msgPayload)
+		return this.SyncLink.SendRaw(msgPayload)
 	}
 	return errors.New("[p2p]sync link invalid")
 }
@@ -254,7 +254,7 @@ func (this *Peer) SendToSync(msgType string, msgPayload []byte) error {
 //SendToCons call consensus link to send buffer
 func (this *Peer) SendToCons(msgType string, msgPayload []byte) error {
 	if this.ConsLink != nil && this.ConsLink.Valid() {
-		return this.ConsLink.Tx(msgType, msgPayload)
+		return this.ConsLink.SendRaw(msgPayload)
 	}
 	return errors.New("[p2p]cons link invalid")
 }
@@ -343,8 +343,8 @@ func (this *Peer) AttachConsChan(msgchan chan *types.MsgPayload) {
 	this.ConsLink.SetChan(msgchan)
 }
 
-//SendMsg transfer buffer by sync or cons link
-func (this *Peer) SendMsg(msg types.Message, isConsensus bool) error {
+//Send transfer buffer by sync or cons link
+func (this *Peer) Send(msg types.Message, isConsensus bool) error {
 	sink := comm.NewZeroCopySink(nil)
 	err := types.WriteMessage(sink, msg)
 	if err != nil {
@@ -352,10 +352,10 @@ func (this *Peer) SendMsg(msg types.Message, isConsensus bool) error {
 		return err
 	}
 
-	return this.Send(msg.CmdType(), sink.Bytes(), isConsensus)
+	return this.SendRaw(msg.CmdType(), sink.Bytes(), isConsensus)
 }
 
-func (this *Peer) Send(msgType string, msgPayload []byte, isConsensus bool) error {
+func (this *Peer) SendRaw(msgType string, msgPayload []byte, isConsensus bool) error {
 	if isConsensus && this.ConsLink.Valid() {
 		return this.SendToCons(msgType, msgPayload)
 	}


### PR DESCRIPTION
1. serialize before transmitting on peer link
2. improve msg header deserialization
3. change Send(msg) to Send(msgType, msgPayload), add SendMsg(msg) interface

in broadcasting, firstly serialize msg to []byte, then transmitting on each peer link with Send(payload)