### PR TITLE
deserializing public key failed: unrecognized algorithm label #917

### DIFF
--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -633,10 +633,18 @@ func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]*t
 	var i uint32
 	for i = 1; i <= count; i++ {
 		hash := ledger.DefLedger.GetBlockHash(stopHeight + i)
-		hd, err := ledger.DefLedger.GetRawHeaderByHash(hash)
+		header, err := ledger.DefLedger.GetHeaderByHash(hash)
 		if err != nil {
 			log.Debugf("[p2p]net_server GetBlockWithHeight failed with err=%s, hash=%x,height=%d\n", err.Error(), hash, stopHeight+i)
 			return nil, err
+		}
+
+		sink := common.NewZeroCopySink(nil)
+		header.Serialization(sink)
+
+		hd := &types.RawHeader{
+			Height:  header.Height,
+			Payload: sink.Bytes(),
 		}
 		headers = append(headers, hd)
 	}


### PR DESCRIPTION
分析了问题的原因，GetRawHeaderByHash的时候，这个结构体里其实是在SaveHeader的时候

sink.WriteUint32(uint32(len(block.Transactions)))

    for _, tx := range block.Transactions {

        txHash := tx.Hash()

        sink.WriteHash(txHash)

    }

    this.store.BatchPut(key, sink.Bytes())

加了Transaction的长度和TransactionHash， 而在受到消息后

deserializationUnsigned的时候其实是没有解析这部分，所以除了第一个消息能正常解析外，后面的消息会错位，导致解析出错。

尝试做了修改本地验证通过
