### PR TITLE
supplement of xshard contract lock

### DIFF
--- a/common/zero_copy_sink.go
+++ b/common/zero_copy_sink.go
@@ -161,6 +161,13 @@ func (self *ZeroCopySink) WriteAddrList(addrs []Address) {
 	}
 }
 
+func (self *ZeroCopySink) WriteVarBytesArray(data [][]byte) {
+	self.WriteUint64(uint64(len(data)))
+	for _, b := range data {
+		self.WriteVarBytes(b)
+	}
+}
+
 func (self *ZeroCopySink) WriteHash(hash Uint256) {
 	self.WriteBytes(hash[:])
 }

--- a/common/zero_copy_sink.go
+++ b/common/zero_copy_sink.go
@@ -162,7 +162,7 @@ func (self *ZeroCopySink) WriteAddrList(addrs []Address) {
 }
 
 func (self *ZeroCopySink) WriteVarBytesArray(data [][]byte) {
-	self.WriteUint64(uint64(len(data)))
+	self.WriteUint32(uint32(len(data)))
 	for _, b := range data {
 		self.WriteVarBytes(b)
 	}

--- a/common/zero_copy_source.go
+++ b/common/zero_copy_source.go
@@ -212,12 +212,12 @@ func (self *ZeroCopySource) ReadAddrList() ([]Address, error) {
 }
 
 func (self *ZeroCopySource) ReadVarBytesArray() ([][]byte, error) {
-	num, eof := self.NextUint64()
+	num, eof := self.NextUint32()
 	if eof {
 		return nil, io.ErrUnexpectedEOF
 	}
-	data := make([][]byte, num)
-	for i := uint64(0); i < num; i++ {
+	data := make([][]byte, 0)
+	for i := uint32(0); i < num; i++ {
 		b, _, irr, eof := self.NextVarBytes()
 		if irr {
 			return nil, ErrIrregularData
@@ -225,7 +225,7 @@ func (self *ZeroCopySource) ReadVarBytesArray() ([][]byte, error) {
 		if eof {
 			return nil, io.ErrUnexpectedEOF
 		}
-		data[i] = b
+		data = append(data, b)
 	}
 	return data, nil
 }

--- a/common/zero_copy_source.go
+++ b/common/zero_copy_source.go
@@ -211,6 +211,25 @@ func (self *ZeroCopySource) ReadAddrList() ([]Address, error) {
 	return addrs, nil
 }
 
+func (self *ZeroCopySource) ReadVarBytesArray() ([][]byte, error) {
+	num, eof := self.NextUint64()
+	if eof {
+		return nil, io.ErrUnexpectedEOF
+	}
+	data := make([][]byte, num)
+	for i := uint64(0); i < num; i++ {
+		b, _, irr, eof := self.NextVarBytes()
+		if irr {
+			return nil, ErrIrregularData
+		}
+		if eof {
+			return nil, io.ErrUnexpectedEOF
+		}
+		data[i] = b
+	}
+	return data, nil
+}
+
 func (self *ZeroCopySource) NextHash() (data Uint256, eof bool) {
 	var buf []byte
 	buf, eof = self.NextBytes(UINT256_SIZE)

--- a/core/chainmgr/xshard_state/xshard_state.go
+++ b/core/chainmgr/xshard_state/xshard_state.go
@@ -107,6 +107,7 @@ type TxState struct {
 	Result         []byte
 	ResultErr      string
 	LockedAddress  []common.Address
+	LockedKeys     [][]byte
 	WriteSet       *overlaydb.MemDB
 	Notify         *event.ExecuteNotify
 }
@@ -301,6 +302,11 @@ func (self *TxState) Deserialization(source *common.ZeroCopySource) error {
 		return err
 	}
 
+	self.LockedKeys, err = source.ReadVarBytesArray()
+	if err != nil {
+		return err
+	}
+
 	buf, _, irr, eof := source.NextVarBytes()
 	if irr {
 		return common.ErrIrregularData
@@ -389,6 +395,7 @@ func (self *TxState) Serialization(sink *common.ZeroCopySink) {
 	self.WriteSet.Serialization(sink)
 
 	sink.WriteAddrList(self.LockedAddress)
+	sink.WriteVarBytesArray(self.LockedKeys)
 
 	buf, _ := json.Marshal(self.Notify)
 	sink.WriteVarBytes(buf)

--- a/core/store/common/data_entry_prefix.go
+++ b/core/store/common/data_entry_prefix.go
@@ -51,11 +51,11 @@ const (
 	XSHARD_STATE               DataEntryPrefix = 0x34
 	XSHARD_KEY_SHARDS_IN_BLOCK                 = 0x35 // with block#, contains to-shard list
 	XSHARD_KEY_REQS_IN_BLOCK                   = 0x36 // with block# - shard#, containers requests to shard#
-	XSHARD_KEY_LOCKED_ADDRESS                  = 0x37 // save current locked contrqct address
+	ST_CONTRACT_META_DATA      DataEntryPrefix = 0x37 // contract meta data
 	XSHARD_KEY_MSG_HASH        DataEntryPrefix = 0x38 //shard msg key
 	CROSS_SHARD_MSG            DataEntryPrefix = 0x39 //cross shard msg data
 	SHARD_CONFIG_DATA          DataEntryPrefix = 0x40 //all shard consensus config
 	CROSS_SHARD_HEIGHT         DataEntryPrefix = 0x41 //all shard consensus height info
-
-	ST_CONTRACT_META_DATA DataEntryPrefix = 0x40 // contract meta data
+	XSHARD_KEY_LOCKED_ADDRESS                  = 0x42 // save current locked contrqct address
+	XSHARD_KEY_LOCKED_KEY      DataEntryPrefix = 0x43
 )

--- a/core/store/common/data_entry_prefix.go
+++ b/core/store/common/data_entry_prefix.go
@@ -37,6 +37,8 @@ const (
 
 	IX_HEADER_HASH_LIST DataEntryPrefix = 0x09 //Block height => block hash key prefix
 
+	ST_CONTRACT_META_DATA DataEntryPrefix = 0x0a // contract meta data
+
 	//SYSTEM
 	SYS_CURRENT_BLOCK      DataEntryPrefix = 0x10 //Current block key prefix
 	SYS_VERSION            DataEntryPrefix = 0x11 //Store version key prefix
@@ -51,11 +53,12 @@ const (
 	XSHARD_STATE               DataEntryPrefix = 0x34
 	XSHARD_KEY_SHARDS_IN_BLOCK                 = 0x35 // with block#, contains to-shard list
 	XSHARD_KEY_REQS_IN_BLOCK                   = 0x36 // with block# - shard#, containers requests to shard#
-	ST_CONTRACT_META_DATA      DataEntryPrefix = 0x37 // contract meta data
-	XSHARD_KEY_MSG_HASH        DataEntryPrefix = 0x38 //shard msg key
-	CROSS_SHARD_MSG            DataEntryPrefix = 0x39 //cross shard msg data
-	SHARD_CONFIG_DATA          DataEntryPrefix = 0x40 //all shard consensus config
-	CROSS_SHARD_HEIGHT         DataEntryPrefix = 0x41 //all shard consensus height info
-	XSHARD_KEY_LOCKED_ADDRESS                  = 0x42 // save current locked contrqct address
-	XSHARD_KEY_LOCKED_KEY      DataEntryPrefix = 0x43
+	XSHARD_KEY_MSG_HASH        DataEntryPrefix = 0x37 //shard msg key
+	XSHARD_KEY_LOCKED_ADDRESS                  = 0x38 // save current locked contrqct address
+	XSHARD_KEY_LOCKED_KEY      DataEntryPrefix = 0x39
+
+	CROSS_SHARD_MSG    DataEntryPrefix = 0x40 //cross shard msg data
+	CROSS_SHARD_HEIGHT DataEntryPrefix = 0x41 //all shard consensus height info
+
+	SHARD_CONFIG_DATA DataEntryPrefix = 0x42 //all shard consensus config
 )

--- a/core/store/ledgerstore/ledger_store.go
+++ b/core/store/ledgerstore/ledger_store.go
@@ -699,25 +699,13 @@ func (this *LedgerStoreImp) executeBlock(block *types.Block) (result store.Execu
 	// execute transactions
 	for _, tx := range block.Transactions {
 		cache.Reset()
-		<<<<<<< HEAD
 		if tx.TxType == types.ShardCall {
 			txHash := tx.Hash()
 			err = fmt.Errorf("handleTransaction failed tx type:%d,txHash:%s", types.ShardCall, txHash.ToHexString())
 			return
 		}
-		notify, e := HandleTransaction(this, overlay, cache, gasTable, lockedAddress, xshardDB, block.Header, tx)
-		====== =
 		notify, e := HandleTransaction(this, overlay, cache, gasTable, lockedAddress, lockedKeys, xshardDB,
 			block.Header, tx)
-		>>>>>>> b2e40d2e... add
-		locked
-		keys
-		check
-		while
-		shard
-		call
-		and
-		invoke
 		if e != nil {
 			err = e
 			return

--- a/core/store/ledgerstore/state_store.go
+++ b/core/store/ledgerstore/state_store.go
@@ -292,6 +292,19 @@ func (self *StateStore) GetCurrentLockedAddress() ([]common.Address, error) {
 	return source.ReadAddrList()
 }
 
+func (self *StateStore) GetCurrentLockedKeys() ([][]byte, error) {
+	buf, err := self.store.Get([]byte{byte(scom.XSHARD_KEY_LOCKED_KEY)})
+	if err == scom.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	source := common.NewZeroCopySource(buf)
+
+	return source.ReadVarBytesArray()
+}
+
 func (self *StateStore) GetRelatedShardIDsInBlock(blockHeight uint32) ([]common.ShardID, error) {
 	key := common.NewZeroCopySink(8)
 	key.WriteByte(byte(scom.XSHARD_KEY_SHARDS_IN_BLOCK))

--- a/core/store/ledgerstore/tx_handler.go
+++ b/core/store/ledgerstore/tx_handler.go
@@ -418,7 +418,7 @@ func handleShardPrepareMsg(prepMsg *xshard_types.XShardPrepareMsg, store store.L
 		}
 		var addr common.Address
 		copy(addr[:], key)
-		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress {
+		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress && addr != utils.OngContractAddress {
 			readContract[addr] = struct{}{}
 		}
 		lockKey(txLockedKeys, key)
@@ -478,7 +478,7 @@ func handleShardPrepareMsg(prepMsg *xshard_types.XShardPrepareMsg, store store.L
 		}
 		var addr common.Address
 		copy(addr[:], key[1:])
-		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress {
+		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress && addr != utils.OngContractAddress {
 			readContract[addr] = struct{}{}
 		}
 		lockKey(txLockedKeys, key)
@@ -751,7 +751,7 @@ func handleShardRespMsg(msg *xshard_types.XShardTxRsp, store store.LedgerStore, 
 		}
 		var addr common.Address
 		copy(addr[:], key)
-		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress {
+		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress && addr != utils.OngContractAddress {
 			readContract[addr] = struct{}{}
 		}
 		lockKey(lockedKeys, key)
@@ -880,7 +880,7 @@ func handleShardRespMsg(msg *xshard_types.XShardTxRsp, store store.LedgerStore, 
 		}
 		var addr common.Address
 		copy(addr[:], key[1:])
-		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress {
+		if addr != utils.ShardAssetAddress && addr != utils.ShardMgmtContractAddress && addr != utils.OngContractAddress {
 			readContract[addr] = struct{}{}
 		}
 		lockKey(lockedKeys, key)
@@ -1342,12 +1342,17 @@ func shouldLock(key []byte) bool {
 		return false
 	}
 	if bytes.Equal(key[:common.ADDR_LEN], utils.ShardAssetAddress[:]) &&
-		bytes.Equal(key[:common.ADDR_LEN], utils.OngContractAddress[:]) {
+		bytes.Equal(key[:common.ADDR_LEN], utils.OngContractAddress[:]) &&
+		bytes.Equal(key[:common.ADDR_LEN], utils.ShardMgmtContractAddress[:]) {
 		return true
 	}
 	// key contains storage prefix
+	if keyLen < common.ADDR_LEN+1 {
+		return false
+	}
 	if bytes.Equal(key[1:common.ADDR_LEN], utils.ShardAssetAddress[:]) &&
-		bytes.Equal(key[1:common.ADDR_LEN], utils.OngContractAddress[:]) {
+		bytes.Equal(key[1:common.ADDR_LEN], utils.OngContractAddress[:]) &&
+		bytes.Equal(key[1:common.ADDR_LEN], utils.ShardMgmtContractAddress[:]) {
 		return true
 	}
 	return false

--- a/core/store/ledgerstore/tx_handler.go
+++ b/core/store/ledgerstore/tx_handler.go
@@ -546,8 +546,6 @@ func handleShardNotifyMsg(msg *xshard_types.XShardNotify, store store.LedgerStor
 		gasConsume = neovm.MIN_TRANSACTION_GAS
 	}
 	if tx.GasPrice > 0 {
-		// add payer permission
-		tx.SignedAddr = append(tx.SignedAddr, tx.Payer) // TODO: consider risk
 		cfg := &smartcontract.Config{
 			ShardID:   shardId,
 			Time:      header.Timestamp,
@@ -1184,7 +1182,7 @@ func calcGasByCodeLen(codeLen int, codeGas uint64) uint64 {
 	return uint64(codeLen/neovm.PER_UNIT_CODE_LEN) * codeGas
 }
 
-func buildTx(payer, contract common.Address, method string, args []interface{}, shardId, gasLimit uint64,
+func buildTx(originalPayer, contract common.Address, method string, args []interface{}, shardId, gasLimit uint64,
 	nonce uint32) (*types.Transaction, error) {
 	invokeCode := []byte{}
 	var err error = nil
@@ -1206,7 +1204,7 @@ func buildTx(payer, contract common.Address, method string, args []interface{}, 
 		GasLimit: gasLimit,
 		TxType:   types.Invoke,
 		Nonce:    nonce,
-		Payer:    payer,
+		Payer:    originalPayer,
 		Payload:  invokePayload,
 		Sigs:     make([]types.Sig, 0, 0),
 	}
@@ -1214,6 +1212,7 @@ func buildTx(payer, contract common.Address, method string, args []interface{}, 
 	if err != nil {
 		return nil, fmt.Errorf("buildTx: build tx failed, err: %s", err)
 	}
+	tx.SignedAddr = append(tx.SignedAddr, originalPayer)
 	return tx, nil
 }
 

--- a/core/store/ledgerstore/tx_handler.go
+++ b/core/store/ledgerstore/tx_handler.go
@@ -495,6 +495,9 @@ func handleShardPrepareMsg(prepMsg *xshard_types.XShardPrepareMsg, store store.L
 		lockedKeys[string(key)] = struct{}{}
 		txState.LockedKeys = append(txState.LockedKeys, []byte(key))
 	}
+	sort.SliceStable(txState.LockedKeys, func(i, j int) bool {
+		return bytes.Compare(txState.LockedKeys[i], txState.LockedKeys[j]) < 0
+	})
 	common.SortAddress(shardTxLockAddr)
 	txState.LockedAddress = shardTxLockAddr
 	txState.Notify = contractEvent
@@ -887,6 +890,9 @@ func handleShardRespMsg(msg *xshard_types.XShardTxRsp, store store.LedgerStore, 
 		lockedKeys[string(key)] = struct{}{}
 		txState.LockedKeys = append(txState.LockedKeys, []byte(key))
 	}
+	sort.SliceStable(txState.LockedKeys, func(i, j int) bool {
+		return bytes.Compare(txState.LockedKeys[i], txState.LockedKeys[j]) < 0
+	})
 	common.SortAddress(shardTxLockAddr)
 	txState.LockedAddress = shardTxLockAddr
 	txState.Notify = evts

--- a/core/store/ledgerstore/tx_handler.go
+++ b/core/store/ledgerstore/tx_handler.go
@@ -1122,7 +1122,7 @@ func HandleInvokeTransaction(store store.LedgerStore, overlay *overlaydb.Overlay
 	})
 	for txLockedKey := range txLockedKeys {
 		if _, ok := lockedKeys[txLockedKey]; ok {
-			return
+			return nil, fmt.Errorf("contract some status locked")
 		}
 	}
 	cnotify := notify.ContractEvent
@@ -1322,9 +1322,9 @@ func shouldLock(key []byte) bool {
 	if keyLen < common.ADDR_LEN+1 {
 		return false
 	}
-	if bytes.Equal(key[1:common.ADDR_LEN], utils.ShardAssetAddress[:]) &&
-		bytes.Equal(key[1:common.ADDR_LEN], utils.OngContractAddress[:]) &&
-		bytes.Equal(key[1:common.ADDR_LEN], utils.ShardMgmtContractAddress[:]) {
+	cmpKey := key[1 : common.ADDR_LEN+1]
+	if bytes.Equal(cmpKey, utils.ShardAssetAddress[:]) || bytes.Equal(cmpKey, utils.OngContractAddress[:]) ||
+		bytes.Equal(cmpKey, utils.ShardMgmtContractAddress[:]) {
 		return true
 	}
 	return false

--- a/core/xshard_types/xshard_msg.go
+++ b/core/xshard_types/xshard_msg.go
@@ -385,7 +385,7 @@ func (this *CrossShardTx) Deserialization(source *common.ZeroCopySource) error {
 	if eof {
 		return io.ErrUnexpectedEOF
 	}
-	this.Txs = make([][]byte, num)
+	this.Txs = make([][]byte, 0)
 	for i := uint64(0); i < num; i++ {
 		data, _, irr, eof := source.NextVarBytes()
 		if irr {
@@ -394,7 +394,7 @@ func (this *CrossShardTx) Deserialization(source *common.ZeroCopySource) error {
 		if eof {
 			return io.ErrUnexpectedEOF
 		}
-		this.Txs[i] = data
+		this.Txs = append(this.Txs, data)
 	}
 	return nil
 }

--- a/smartcontract/service/native/native_service.go
+++ b/smartcontract/service/native/native_service.go
@@ -28,13 +28,14 @@ import (
 	"github.com/ontio/ontology/core/xshard_types"
 	"github.com/ontio/ontology/smartcontract/context"
 	"github.com/ontio/ontology/smartcontract/event"
+	"github.com/ontio/ontology/smartcontract/service/native/utils"
 	"github.com/ontio/ontology/smartcontract/states"
 	sstates "github.com/ontio/ontology/smartcontract/states"
 	"github.com/ontio/ontology/smartcontract/storage"
 )
 
 type (
-	Handler         func(native *NativeService) ([]byte, error)
+	Handler func(native *NativeService) ([]byte, error)
 	RegisterService func(native *NativeService)
 )
 
@@ -71,6 +72,10 @@ func (this *NativeService) Invoke() (interface{}, error) {
 	contract := this.InvokeParam
 	if _, ok := this.LockedAddress[contract.Address]; ok {
 		return false, fmt.Errorf("contract is locked to call: %s", contract.Address.ToHexString())
+	}
+	if this.Tx.TxType == types.ShardCall &&
+		contract.Address != utils.OngContractAddress && contract.Address != utils.ShardAssetAddress {
+		return false, fmt.Errorf("native contract address %x cannot be invoked by shardcall", contract.Address)
 	}
 	services, ok := Contracts[contract.Address]
 	if !ok {

--- a/smartcontract/service/native/native_service.go
+++ b/smartcontract/service/native/native_service.go
@@ -28,14 +28,13 @@ import (
 	"github.com/ontio/ontology/core/xshard_types"
 	"github.com/ontio/ontology/smartcontract/context"
 	"github.com/ontio/ontology/smartcontract/event"
-	"github.com/ontio/ontology/smartcontract/service/native/utils"
 	"github.com/ontio/ontology/smartcontract/states"
 	sstates "github.com/ontio/ontology/smartcontract/states"
 	"github.com/ontio/ontology/smartcontract/storage"
 )
 
 type (
-	Handler func(native *NativeService) ([]byte, error)
+	Handler         func(native *NativeService) ([]byte, error)
 	RegisterService func(native *NativeService)
 )
 
@@ -72,10 +71,6 @@ func (this *NativeService) Invoke() (interface{}, error) {
 	contract := this.InvokeParam
 	if _, ok := this.LockedAddress[contract.Address]; ok {
 		return false, fmt.Errorf("contract is locked to call: %s", contract.Address.ToHexString())
-	}
-	if this.Tx.TxType == types.ShardCall &&
-		contract.Address != utils.OngContractAddress && contract.Address != utils.ShardAssetAddress {
-		return false, fmt.Errorf("native contract address %x cannot be invoked by shardcall", contract.Address)
 	}
 	services, ok := Contracts[contract.Address]
 	if !ok {

--- a/smartcontract/service/native/shard_stake/params.go
+++ b/smartcontract/service/native/shard_stake/params.go
@@ -156,13 +156,13 @@ func (this *UnfreezeFromShardParam) Deserialize(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("deserialize: read value len failed, err: %s", err)
 	}
-	this.Value = make([]*PeerAmount, num)
+	this.Value = make([]*PeerAmount, 0)
 	for i := uint64(0); i < num; i++ {
 		value := &PeerAmount{}
 		if err := value.Deserialize(r); err != nil {
 			return fmt.Errorf("deserialize: read value failed, index %d, err: %s", i, err)
 		}
-		this.Value[i] = value
+		this.Value = append(this.Value, value)
 	}
 	return nil
 }
@@ -381,13 +381,13 @@ func (this *UserStakeParam) Deserialize(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("deserialize: read value len failed, err: %s", err)
 	}
-	this.Value = make([]*PeerAmount, num)
+	this.Value = make([]*PeerAmount, 0)
 	for i := uint64(0); i < num; i++ {
 		value := &PeerAmount{}
 		if err := value.Deserialize(r); err != nil {
 			return fmt.Errorf("deserialize: read value failed, index %d, err: %s", i, err)
 		}
-		this.Value[i] = value
+		this.Value = append(this.Value, value)
 	}
 	return nil
 }

--- a/smartcontract/service/native/shardasset/oep4/events.go
+++ b/smartcontract/service/native/shardasset/oep4/events.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	EVENT_TRANSFER        = "transfer"
-	EVENT_APPROVE         = "approve"
+	EVENT_APPROVE         = "approval"
 	EVENT_MINT            = "mint"
 	EVENT_BURN            = "burn"
 	EVENT_XSHARD_TRANSFER = "xshardTransfer"
@@ -89,23 +89,23 @@ func (this *XShardReceiveEvent) ToNotify() []interface{} {
 }
 
 type MintEvent struct {
-	User    common.Address
 	AssetId AssetId
+	User    common.Address
 	Amount  *big.Int
 }
 
 func (this *MintEvent) ToNotify() []interface{} {
-	return []interface{}{EVENT_MINT, this.User.ToBase58(), uint64(this.AssetId), this.Amount.String()}
+	return []interface{}{EVENT_MINT, uint64(this.AssetId), this.User.ToBase58(), this.Amount.String()}
 }
 
 type BurnEvent struct {
-	User    common.Address
 	AssetId AssetId
+	User    common.Address
 	Amount  *big.Int
 }
 
 func (this *BurnEvent) ToNotify() []interface{} {
-	return []interface{}{EVENT_BURN, this.User.ToBase58(), uint64(this.AssetId), this.Amount.String()}
+	return []interface{}{EVENT_BURN, uint64(this.AssetId), this.User.ToBase58(), this.Amount.String()}
 }
 
 func NotifyEvent(native *native.NativeService, notify []interface{}) {

--- a/smartcontract/service/native/shardasset/oep4/methods.go
+++ b/smartcontract/service/native/shardasset/oep4/methods.go
@@ -58,17 +58,15 @@ func transfer(native *native.NativeService, param *TransferParam) error {
 }
 
 func userBurn(native *native.NativeService, asset AssetId, user common.Address, amount *big.Int) error {
-	if native.ShardID.IsRootShard() {
-		totalSupply, err := getTotalSupply(native, asset)
-		if err != nil {
-			return fmt.Errorf("userBurn: failed, err: %s", err)
-		}
-		if totalSupply.Cmp(amount) < 0 {
-			return fmt.Errorf("userBurn: total supply not enough")
-		}
-		totalSupply.Sub(totalSupply, amount)
-		setTotalSupply(native, asset, totalSupply)
+	totalSupply, err := getTotalSupply(native, asset)
+	if err != nil {
+		return fmt.Errorf("userBurn: failed, err: %s", err)
 	}
+	if totalSupply.Cmp(amount) < 0 {
+		return fmt.Errorf("userBurn: total supply not enough")
+	}
+	totalSupply.Sub(totalSupply, amount)
+	setTotalSupply(native, asset, totalSupply)
 
 	balance, err := getUserBalance(native, asset, user)
 	if err != nil {
@@ -83,14 +81,12 @@ func userBurn(native *native.NativeService, asset AssetId, user common.Address, 
 }
 
 func userMint(native *native.NativeService, asset AssetId, user common.Address, amount *big.Int) error {
-	if native.ShardID.IsRootShard() {
-		totalSupply, err := getTotalSupply(native, asset)
-		if err != nil {
-			return fmt.Errorf("userMint: failed, err: %s", err)
-		}
-		totalSupply.Add(totalSupply, amount)
-		setTotalSupply(native, asset, totalSupply)
+	totalSupply, err := getTotalSupply(native, asset)
+	if err != nil {
+		return fmt.Errorf("userMint: failed, err: %s", err)
 	}
+	totalSupply.Add(totalSupply, amount)
+	setTotalSupply(native, asset, totalSupply)
 	balance, err := getUserBalance(native, asset, user)
 	if err != nil {
 		return fmt.Errorf("userMint: failed, err: %s", err)

--- a/smartcontract/service/native/shardasset/oep4/params.go
+++ b/smartcontract/service/native/shardasset/oep4/params.go
@@ -232,13 +232,13 @@ func (this *MultiTransferParam) Deserialize(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("deserialize: read transfers num failed, err: %s", err)
 	}
-	this.Transfers = make([]*TransferParam, num)
+	this.Transfers = make([]*TransferParam, 0)
 	for i := uint64(0); i < num; i++ {
 		tran := &TransferParam{}
 		if err := tran.Deserialize(r); err != nil {
 			return fmt.Errorf("deserialize: read transfer failed, index %d, err: %s", i, err)
 		}
-		this.Transfers[i] = tran
+		this.Transfers = append(this.Transfers, tran)
 	}
 	return nil
 }

--- a/smartcontract/service/native/shardasset/oep4/utils.go
+++ b/smartcontract/service/native/shardasset/oep4/utils.go
@@ -123,7 +123,7 @@ func getTotalSupply(native *native.NativeService, asset AssetId) (*big.Int, erro
 		return nil, fmt.Errorf("getTotalSupply: read db failed, err: %s", err)
 	}
 	if len(raw) == 0 {
-		return nil, fmt.Errorf("getTotalSupply: store is empty")
+		return big.NewInt(0), nil
 	}
 	storeValue, err := states.GetValueFromRawStorageItem(raw)
 	if err != nil {

--- a/smartcontract/service/native/shardasset/oep4/utils.go
+++ b/smartcontract/service/native/shardasset/oep4/utils.go
@@ -61,32 +61,32 @@ func genAssetIdKey(assetAddr common.Address) []byte {
 
 func genAssetTotalSupplyKey(id AssetId) []byte {
 	assetBytes := utils.GetUint64Bytes(uint64(id))
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_TOTAL_SUPPLY))
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_TOTAL_SUPPLY), assetBytes)
 }
 
 func genBalanceKey(asset AssetId, user common.Address) []byte {
 	assetBytes := utils.GetUint64Bytes(uint64(asset))
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_BALANCE), user[:])
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_BALANCE), assetBytes, user[:])
 }
 
 func genShardSupplyInfoKey(asset AssetId) []byte {
 	assetBytes := utils.GetUint64Bytes(uint64(asset))
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_SHARD_SUPPLY))
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_SHARD_SUPPLY), assetBytes)
 }
 
 func genAllowanceKey(asset AssetId, owner, spender common.Address) []byte {
 	assetBytes := utils.GetUint64Bytes(uint64(asset))
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_ALLOWANCE), owner[:], spender[:])
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_ALLOWANCE), assetBytes, owner[:], spender[:])
 }
 
 func genXShardTransferNumKey(asset AssetId, user common.Address) []byte {
 	assetBytes := utils.GetUint64Bytes(uint64(asset))
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_TRANSFER_NUM), user[:])
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_TRANSFER_NUM), assetBytes, user[:])
 }
 
 func genXShardTransferKey(asset AssetId, user common.Address, transferId *big.Int) []byte {
 	assetBytes := utils.GetUint64Bytes(uint64(asset))
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_XSHARD_TRANSFER), user[:],
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_XSHARD_TRANSFER), assetBytes, user[:],
 		common.BigIntToNeoBytes(transferId)[:])
 }
 
@@ -94,7 +94,7 @@ func genXShardReceiveKey(asset AssetId, user common.Address, fromShard common.Sh
 	assetBytes := utils.GetUint64Bytes(uint64(asset))
 	shardIdBytes := utils.GetUint64Bytes(fromShard.ToUint64())
 	tranIdBytes := common.BigIntToNeoBytes(transferId)[:]
-	return utils.ConcatKey(utils.ShardAssetAddress, assetBytes, []byte(KEY_OEP4_XSHARD_RECEIVE), shardIdBytes, user[:],
+	return utils.ConcatKey(utils.ShardAssetAddress, []byte(KEY_OEP4_XSHARD_RECEIVE), assetBytes, shardIdBytes, user[:],
 		tranIdBytes)
 }
 

--- a/smartcontract/service/native/shardmgmt/param.go
+++ b/smartcontract/service/native/shardmgmt/param.go
@@ -266,13 +266,13 @@ func (this *ApproveJoinShardParam) Deserialize(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("deserialize: read peers num failed, err: %s", err)
 	}
-	this.PeerPubKey = make([]string, num)
+	this.PeerPubKey = make([]string, 0)
 	for i := uint64(0); i < num; i++ {
 		peer, err := serialization.ReadString(r)
 		if err != nil {
 			return fmt.Errorf("deserialize: read peer failed, index %d, err: %s", i, err)
 		}
-		this.PeerPubKey[i] = peer
+		this.PeerPubKey = append(this.PeerPubKey, peer)
 	}
 	return nil
 }

--- a/smartcontract/service/native/shardmgmt/shardmgmt.go
+++ b/smartcontract/service/native/shardmgmt/shardmgmt.go
@@ -281,13 +281,13 @@ func ConfigShard(native *native.NativeService) ([]byte, error) {
 		return utils.BYTE_FALSE, fmt.Errorf("ConfigShard: decode config failed, err: %s", err)
 	}
 	if err := utils.CheckVBFTConfig(cfg); err != nil {
-		return utils.BYTE_FALSE, fmt.Errorf("ActivateShard: failed, err: %s", err)
+		return utils.BYTE_FALSE, fmt.Errorf("ConfigShard: failed, err: %s", err)
 	}
 	shard.Config.VbftCfg = cfg
 	shard.State = shardstates.SHARD_STATE_CONFIGURED
 
 	if err := initStakeContractShard(native, params.ShardID, uint64(cfg.MinInitStake), params.StakeAssetAddress); err != nil {
-		return utils.BYTE_FALSE, fmt.Errorf("CreateShard: failed, err: %s", err)
+		return utils.BYTE_FALSE, fmt.Errorf("ConfigShard: failed, err: %s", err)
 	}
 	setShardState(native, contract, shard)
 

--- a/smartcontract/service/neovm/native.go
+++ b/smartcontract/service/neovm/native.go
@@ -52,7 +52,8 @@ func NativeInvoke(service *NeoVmService, engine *vm.ExecutionEngine) error {
 	if err != nil {
 		return fmt.Errorf("invoke native contract:%s, address invalid", address)
 	}
-	if service.Tx.TxType == ctype.ShardCall && addr != utils.OngContractAddress && addr != utils.ShardAssetAddress {
+	if service.Tx.TxType == ctype.ShardCall && addr != utils.OngContractAddress && addr != utils.ShardAssetAddress &&
+		addr != utils.ShardMgmtContractAddress {
 		return fmt.Errorf("native contract address %x cannot be invoked by shardcall", addr)
 	}
 	method, err := vm.PopByteArray(engine)

--- a/smartcontract/service/neovm/native.go
+++ b/smartcontract/service/neovm/native.go
@@ -27,7 +27,9 @@ import (
 
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/common/serialization"
+	ctype "github.com/ontio/ontology/core/types"
 	"github.com/ontio/ontology/smartcontract/service/native"
+	"github.com/ontio/ontology/smartcontract/service/native/utils"
 	"github.com/ontio/ontology/smartcontract/states"
 	vm "github.com/ontio/ontology/vm/neovm"
 	"github.com/ontio/ontology/vm/neovm/types"
@@ -49,6 +51,9 @@ func NativeInvoke(service *NeoVmService, engine *vm.ExecutionEngine) error {
 	addr, err := common.AddressParseFromBytes(address)
 	if err != nil {
 		return fmt.Errorf("invoke native contract:%s, address invalid", address)
+	}
+	if service.Tx.TxType == ctype.ShardCall && addr != utils.OngContractAddress && addr != utils.ShardAssetAddress {
+		return fmt.Errorf("native contract address %x cannot be invoked by shardcall", addr)
 	}
 	method, err := vm.PopByteArray(engine)
 	if err != nil {

--- a/smartcontract/storage/cachedb.go
+++ b/smartcontract/storage/cachedb.go
@@ -179,7 +179,7 @@ func (self *CacheDB) get(prefix common.DataEntryPrefix, key []byte) ([]byte, err
 		}
 		value = v
 		if self.onReadBackend != nil {
-			self.onReadBackend(key, v)
+			self.onReadBackend(self.keyScratch, v)
 		}
 	}
 

--- a/smartcontract/storage/xsharddb.go
+++ b/smartcontract/storage/xsharddb.go
@@ -81,6 +81,14 @@ func (self *XShardDB) SetLockedAddress(addrs []comm.Address) {
 	self.cacheDB.put(common.XSHARD_KEY_LOCKED_ADDRESS, nil, sink.Bytes())
 }
 
+func (self *XShardDB) SetLockedKeys(keys [][]byte) {
+
+	sink := comm.NewZeroCopySink(0)
+	sink.WriteVarBytesArray(keys)
+
+	self.cacheDB.put(common.XSHARD_KEY_LOCKED_KEY, nil, sink.Bytes())
+}
+
 func (self *XShardDB) SetXShardMsgInBlock(blockHeight uint32, msgs []xshard_types.CommonShardMsg) {
 	shardMsgMap := make(map[comm.ShardID][]xshard_types.CommonShardMsg)
 	for _, msg := range msgs {

--- a/smartcontract/storage/xsharddb.go
+++ b/smartcontract/storage/xsharddb.go
@@ -19,11 +19,13 @@
 package storage
 
 import (
+	"bytes"
 	comm "github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/core/chainmgr/xshard_state"
 	"github.com/ontio/ontology/core/store/common"
 	"github.com/ontio/ontology/core/store/overlaydb"
 	"github.com/ontio/ontology/core/xshard_types"
+	"sort"
 )
 
 // CacheDB is smart contract execute cache, it contain transaction cache and block cache
@@ -83,6 +85,9 @@ func (self *XShardDB) SetLockedAddress(addrs []comm.Address) {
 
 func (self *XShardDB) SetLockedKeys(keys [][]byte) {
 
+	sort.SliceStable(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	})
 	sink := comm.NewZeroCopySink(0)
 	sink.WriteVarBytesArray(keys)
 

--- a/smartcontract/test/native_test.go
+++ b/smartcontract/test/native_test.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"github.com/ontio/ontology/common"
+	"github.com/ontio/ontology/core/types"
 	"github.com/ontio/ontology/smartcontract"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -37,7 +38,7 @@ func TestBuildParamToNative(t *testing.T) {
 	config := &smartcontract.Config{
 		Time:   10,
 		Height: 10,
-		Tx:     nil,
+		Tx:     &types.Transaction{},
 	}
 	sc := smartcontract.SmartContract{
 		Config: config,

--- a/smartcontract/testsuite/suite.go
+++ b/smartcontract/testsuite/suite.go
@@ -293,6 +293,7 @@ type ShardContext struct {
 	overlay         *overlaydb.OverlayDB
 	height          uint32
 	LockedAddress   map[common.Address]struct{}
+	LockedKeys      map[string]struct{}
 	LockHistory     map[common.Address]struct{}
 	t               *testing.T
 }
@@ -304,6 +305,7 @@ func NewShardContext(shardID common.ShardID, contract common.Address, t *testing
 		t:               t,
 		overlay:         NewOverlayDB(),
 		LockedAddress:   make(map[common.Address]struct{}),
+		LockedKeys:      make(map[string]struct{}),
 		LockHistory:     make(map[common.Address]struct{}),
 	}
 }
@@ -325,7 +327,7 @@ func (self *ShardContext) InvokeShardContractRaw(method string, args []interface
 	}
 
 	gasTable := make(map[string]uint64)
-	_, err := ledgerstore.HandleInvokeTransaction(nil, self.overlay, gasTable, self.LockedAddress, cache, xshardDB, tx, header, notify)
+	_, err := ledgerstore.HandleInvokeTransaction(nil, self.overlay, gasTable, self.LockedAddress, self.LockedKeys, cache, xshardDB, tx, header, notify)
 	if err != nil {
 		return txHash, nil, err
 	}
@@ -357,7 +359,7 @@ func (self *ShardContext) HandleShardCallMsgs(msgs []xshard_types.CommonShardMsg
 	}
 
 	gasTable := make(map[string]uint64)
-	err := ledgerstore.HandleShardCallTransaction(nil, self.overlay, gasTable, self.LockedAddress, cache, xshardDB, msgs, header, notify)
+	err := ledgerstore.HandleShardCallTransaction(nil, self.overlay, gasTable, self.LockedAddress, self.LockedKeys, cache, xshardDB, msgs, header, notify)
 	assert.Nil(t, err)
 	xshardDB.Commit()
 


### PR DESCRIPTION
1. update xshard asset key prefix and some event name;
2. disable invoke native contract except shardmgmt, shardasset, ong while shard call;
3. lock shardmgmt, shardasset, ong key rather than contract address.