### PR TITLE
Removed unneeded spaces

### DIFF
--- a/common/log/log.go
+++ b/common/log/log.go
@@ -59,8 +59,8 @@ const (
 var (
 	levels = map[int]string{
 		DebugLog: Color(Green, "[DEBUG]"),
-		InfoLog:  Color(Cyan, "[INFO ]"),
-		WarnLog:  Color(Yellow, "[WARN ]"),
+		InfoLog:  Color(Cyan, "[INFO]"),
+		WarnLog:  Color(Yellow, "[WARN]"),
 		ErrorLog: Color(Red, "[ERROR]"),
 		FatalLog: Color(Red, "[FATAL]"),
 		TraceLog: Color(Pink, "[TRACE]"),


### PR DESCRIPTION
Don't need the spaces for `[INFO]` and `[WARN]` 