### PR TITLE
adapt x-shard notify and invoke to runtime api

### DIFF
--- a/cmd/contract_cmd.go
+++ b/cmd/contract_cmd.go
@@ -92,6 +92,7 @@ var (
 					utils.ContractReturnTypeFlag,
 					utils.WalletFileFlag,
 					utils.AccountAddressFlag,
+					utils.ShardIDFlag,
 				},
 			},
 			{
@@ -332,6 +333,7 @@ func invokeContract(ctx *cli.Context) error {
 	}
 	gasPrice := ctx.Uint64(utils.GetFlagName(utils.TransactionGasPriceFlag))
 	gasLimit := ctx.Uint64(utils.GetFlagName(utils.TransactionGasLimitFlag))
+	shardId := ctx.Uint64(utils.GetFlagName(utils.ShardIDFlag))
 	networkId, err := utils.GetNetworkId()
 	if err != nil {
 		return err
@@ -340,7 +342,7 @@ func invokeContract(ctx *cli.Context) error {
 		gasPrice = 0
 	}
 
-	txHash, err := utils.InvokeNeoVMContract(gasPrice, gasLimit, signer, contractAddr, params)
+	txHash, err := utils.InvokeNeoVMContract(shardId, gasPrice, gasLimit, signer, contractAddr, params)
 	if err != nil {
 		return fmt.Errorf("invoke NeoVM contract error:%s", err)
 	}

--- a/cmd/utils/ont.go
+++ b/cmd/utils/ont.go
@@ -691,6 +691,7 @@ func InvokeWasmVMContract(
 
 //Invoke neo vm smart contract. if isPreExec is true, the invoke will not really execute
 func InvokeNeoVMContract(
+	shardId,
 	gasPrice,
 	gasLimit uint64,
 	signer *account.Account,
@@ -700,6 +701,7 @@ func InvokeNeoVMContract(
 	if err != nil {
 		return "", err
 	}
+	tx.ShardID = shardId
 	return InvokeSmartContract(signer, tx)
 }
 

--- a/core/chainmgr/msghandler.go
+++ b/core/chainmgr/msghandler.go
@@ -99,7 +99,7 @@ func (self *ChainManager) onShardActivated(evt *shardstates.ShardActiveEvent) er
 		return fmt.Errorf("shard %d state %d is not active", evt.ShardID, shardState.State)
 	}
 	self.AddShardEventConfig(0, evt.ShardID, shardState.Config, shardState.Peers)
-	if evt.ShardID == self.shardID && evt.ShardID.ParentID() == self.shardID || self.shardID.IsRootShard() {
+	if evt.ShardID != self.shardID || self.shardID.IsRootShard() {
 		log.Infof("self shardID equal evt shardID or is rootshard:%v", evt.ShardID)
 		return nil
 	}

--- a/core/store/ledgerstore/cross_shard_store_test.go
+++ b/core/store/ledgerstore/cross_shard_store_test.go
@@ -55,7 +55,7 @@ func TestSaveCrossShardMsgByHash(t *testing.T) {
 	}
 	msgHash := msg.CrossShardMsgInfo.CrossShardMsgRoot.ToHexString()
 	if crossShardRoot.ToHexString() != msgHash {
-		t.Errorf("crossShardMsg len not match:%d,%d", crossShardRoot.ToHexString(), msgHash)
+		t.Errorf("crossShardMsg len not match:%s, %s", crossShardRoot.ToHexString(), msgHash)
 		return
 	}
 }

--- a/core/store/ledgerstore/tx_handler.go
+++ b/core/store/ledgerstore/tx_handler.go
@@ -580,7 +580,7 @@ func handleShardNotifyMsg(msg *xshard_types.XShardNotify, store store.LedgerStor
 	if gasConsume < neovm.MIN_TRANSACTION_GAS {
 		gasConsume = neovm.MIN_TRANSACTION_GAS
 	}
-	if tx.GasPrice > 0 {
+	if tx.GasPrice > 0 && msg.Contract != utils.ShardMgmtContractAddress && msg.Contract != utils.ShardStakeAddress {
 		cfg := &smartcontract.Config{
 			ShardID:   shardId,
 			Time:      header.Timestamp,
@@ -990,7 +990,8 @@ func HandleInvokeTransaction(store store.LedgerStore, overlay *overlaydb.Overlay
 	tx *types.Transaction, header *types.Header, notify *event.TransactionNotify) (result interface{}, err error) {
 	invoke := tx.Payload.(*payload.InvokeCode)
 	code := invoke.Code
-	sysTransFlag := bytes.Compare(code, ninit.COMMIT_DPOS_BYTES) == 0 || header.Height == 0
+	sysTransFlag := bytes.Compare(code, ninit.COMMIT_DPOS_BYTES) == 0 ||
+		bytes.Compare(code, ninit.SHARD_COMMIT_DPOS_BYTES) == 0 || header.Height == 0
 	txHash := tx.Hash()
 	txState := xshard_state.CreateTxState(xshard_types.ShardTxID(string(txHash[:])))
 

--- a/http/base/common/common.go
+++ b/http/base/common/common.go
@@ -454,6 +454,7 @@ func NewSmartContractTransaction(gasPrice, gasLimit uint64, invokeCode []byte) (
 		Code: invokeCode,
 	}
 	tx := &types.MutableTransaction{
+		Version:  common.CURR_TX_VERSION,
 		GasPrice: gasPrice,
 		GasLimit: gasLimit,
 		TxType:   types.Invoke,

--- a/smartcontract/context/context.go
+++ b/smartcontract/context/context.go
@@ -45,6 +45,8 @@ type ContextRef interface {
 	GetRemainGas() uint64
 	CheckCallShard(fromShard common.ShardID) bool
 	GetMetaData(contract common.Address) (*payload.MetaDataCode, bool, error)
+	NotifyRemoteShard(target common.ShardID, cont common.Address, fee uint64, method string, args []byte)
+	InvokeRemoteShard(target common.ShardID, cont common.Address, method string, args []byte) ([]byte, error)
 }
 
 type Engine interface {

--- a/smartcontract/service/native/shardasset/oep4/methods.go
+++ b/smartcontract/service/native/shardasset/oep4/methods.go
@@ -168,7 +168,7 @@ func notifyShardMint(native *native.NativeService, toShard common.ShardID, param
 	if err := param.Serialize(bf); err != nil {
 		return fmt.Errorf("notifyShardMint: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 0, XSHARD_RECEIVE_ASSET, bf.Bytes())
+	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 20000, XSHARD_RECEIVE_ASSET, bf.Bytes())
 	return nil
 }
 
@@ -194,7 +194,7 @@ func notifyTransferSuccess(native *native.NativeService, toShard common.ShardID,
 	if err := tranSuccParam.Serialize(bf); err != nil {
 		return fmt.Errorf("notifyTransferSuccess: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 0, XSHARD_TRANSFER_SUCC, bf.Bytes())
+	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 20000, XSHARD_TRANSFER_SUCC, bf.Bytes())
 	return nil
 }
 
@@ -203,6 +203,6 @@ func notifyShardReceiveOng(native *native.NativeService, toShard common.ShardID,
 	if err := param.Serialize(bf); err != nil {
 		return fmt.Errorf("notifyShardReceiveOng: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 0, ONG_XSHARD_RECEIVE, bf.Bytes())
+	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 20000, ONG_XSHARD_RECEIVE, bf.Bytes())
 	return nil
 }

--- a/smartcontract/service/native/shardasset/oep4/methods.go
+++ b/smartcontract/service/native/shardasset/oep4/methods.go
@@ -168,7 +168,7 @@ func notifyShardMint(native *native.NativeService, toShard common.ShardID, param
 	if err := param.Serialize(bf); err != nil {
 		return fmt.Errorf("notifyShardMint: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, XSHARD_RECEIVE_ASSET, bf.Bytes())
+	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 0, XSHARD_RECEIVE_ASSET, bf.Bytes())
 	return nil
 }
 
@@ -194,7 +194,7 @@ func notifyTransferSuccess(native *native.NativeService, toShard common.ShardID,
 	if err := tranSuccParam.Serialize(bf); err != nil {
 		return fmt.Errorf("notifyTransferSuccess: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, XSHARD_TRANSFER_SUCC, bf.Bytes())
+	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 0, XSHARD_TRANSFER_SUCC, bf.Bytes())
 	return nil
 }
 
@@ -203,6 +203,6 @@ func notifyShardReceiveOng(native *native.NativeService, toShard common.ShardID,
 	if err := param.Serialize(bf); err != nil {
 		return fmt.Errorf("notifyShardReceiveOng: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, ONG_XSHARD_RECEIVE, bf.Bytes())
+	native.NotifyRemoteShard(toShard, utils.ShardAssetAddress, 0, ONG_XSHARD_RECEIVE, bf.Bytes())
 	return nil
 }

--- a/smartcontract/service/native/shardhotel/hotel.go
+++ b/smartcontract/service/native/shardhotel/hotel.go
@@ -252,7 +252,7 @@ func appcallSendReq(native *native.NativeService, toShard common.ShardID, method
 		_, err := native.InvokeRemoteShard(toShard, utils.ShardHotelAddress, method, payload)
 		return err
 	} else {
-		native.NotifyRemoteShard(toShard, utils.ShardHotelAddress, method, payload)
+		native.NotifyRemoteShard(toShard, utils.ShardHotelAddress, 0, method, payload)
 	}
 	return nil
 }

--- a/smartcontract/service/native/shardhotel/hotel.go
+++ b/smartcontract/service/native/shardhotel/hotel.go
@@ -252,7 +252,7 @@ func appcallSendReq(native *native.NativeService, toShard common.ShardID, method
 		_, err := native.InvokeRemoteShard(toShard, utils.ShardHotelAddress, method, payload)
 		return err
 	} else {
-		native.NotifyRemoteShard(toShard, utils.ShardHotelAddress, 0, method, payload)
+		native.NotifyRemoteShard(toShard, utils.ShardHotelAddress, 20000, method, payload)
 	}
 	return nil
 }

--- a/smartcontract/service/native/shardmgmt/shardmgmt.go
+++ b/smartcontract/service/native/shardmgmt/shardmgmt.go
@@ -669,7 +669,7 @@ func NotifyParentCommitDpos(native *native.NativeService) ([]byte, error) {
 	if err := param.Serialize(bf); err != nil {
 		return utils.BYTE_FALSE, fmt.Errorf("NotifyParentCommitDpos: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(native.ShardID.ParentID(), utils.ShardMgmtContractAddress, 0, COMMIT_DPOS_NAME, bf.Bytes())
+	native.NotifyRemoteShard(native.ShardID.ParentID(), utils.ShardMgmtContractAddress, 20000, COMMIT_DPOS_NAME, bf.Bytes())
 	return utils.BYTE_TRUE, nil
 }
 
@@ -743,7 +743,7 @@ func CommitDpos(native *native.NativeService) ([]byte, error) {
 	evt.ShardID = native.ShardID
 	AddNotification(native, contract, evt)
 	setShardState(native, contract, shard)
-	native.NotifyRemoteShard(shardId, contract, 0, SHARD_COMMIT_DPOS, []byte{})
+	native.NotifyRemoteShard(shardId, contract, 20000, SHARD_COMMIT_DPOS, []byte{})
 	return utils.BYTE_TRUE, nil
 }
 
@@ -771,7 +771,7 @@ func NotifyShardCommitDpos(native *native.NativeService) ([]byte, error) {
 	} else if !isShardCommitting {
 		return utils.BYTE_FALSE, fmt.Errorf("NotifyShardCommitDpos: shard isn't committing")
 	}
-	native.NotifyRemoteShard(shardId, contract, 0, SHARD_COMMIT_DPOS, []byte{})
+	native.NotifyRemoteShard(shardId, contract, 20000, SHARD_COMMIT_DPOS, []byte{})
 	return utils.BYTE_TRUE, nil
 }
 
@@ -811,7 +811,7 @@ func ShardCommitDpos(native *native.NativeService) ([]byte, error) {
 	}
 	sink := common.NewZeroCopySink(0)
 	shardStakeCommitParam.Serialization(sink)
-	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, 0, shard_stake.COMMIT_DPOS, sink.Bytes())
+	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, 20000, shard_stake.COMMIT_DPOS, sink.Bytes())
 	info := &shardstates.ShardCommitDposInfo{
 		TransferId:          transferId,
 		FeeAmount:           balance,
@@ -845,7 +845,7 @@ func ShardRetryCommitDpos(native *native.NativeService) ([]byte, error) {
 	sink := common.NewZeroCopySink(0)
 	shardStakeCommitParam.Serialization(sink)
 	rootShard := common.NewShardIDUnchecked(0)
-	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, 0, shard_stake.COMMIT_DPOS, sink.Bytes())
+	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, 20000, shard_stake.COMMIT_DPOS, sink.Bytes())
 	return utils.BYTE_TRUE, nil
 }
 

--- a/smartcontract/service/native/shardmgmt/shardmgmt.go
+++ b/smartcontract/service/native/shardmgmt/shardmgmt.go
@@ -669,7 +669,7 @@ func NotifyParentCommitDpos(native *native.NativeService) ([]byte, error) {
 	if err := param.Serialize(bf); err != nil {
 		return utils.BYTE_FALSE, fmt.Errorf("NotifyParentCommitDpos: failed, err: %s", err)
 	}
-	native.NotifyRemoteShard(native.ShardID.ParentID(), utils.ShardMgmtContractAddress, COMMIT_DPOS_NAME, bf.Bytes())
+	native.NotifyRemoteShard(native.ShardID.ParentID(), utils.ShardMgmtContractAddress, 0, COMMIT_DPOS_NAME, bf.Bytes())
 	return utils.BYTE_TRUE, nil
 }
 
@@ -743,7 +743,7 @@ func CommitDpos(native *native.NativeService) ([]byte, error) {
 	evt.ShardID = native.ShardID
 	AddNotification(native, contract, evt)
 	setShardState(native, contract, shard)
-	native.NotifyRemoteShard(shardId, contract, SHARD_COMMIT_DPOS, []byte{})
+	native.NotifyRemoteShard(shardId, contract, 0, SHARD_COMMIT_DPOS, []byte{})
 	return utils.BYTE_TRUE, nil
 }
 
@@ -771,7 +771,7 @@ func NotifyShardCommitDpos(native *native.NativeService) ([]byte, error) {
 	} else if !isShardCommitting {
 		return utils.BYTE_FALSE, fmt.Errorf("NotifyShardCommitDpos: shard isn't committing")
 	}
-	native.NotifyRemoteShard(shardId, contract, SHARD_COMMIT_DPOS, []byte{})
+	native.NotifyRemoteShard(shardId, contract, 0, SHARD_COMMIT_DPOS, []byte{})
 	return utils.BYTE_TRUE, nil
 }
 
@@ -811,7 +811,7 @@ func ShardCommitDpos(native *native.NativeService) ([]byte, error) {
 	}
 	sink := common.NewZeroCopySink(0)
 	shardStakeCommitParam.Serialization(sink)
-	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, shard_stake.COMMIT_DPOS, sink.Bytes())
+	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, 0, shard_stake.COMMIT_DPOS, sink.Bytes())
 	info := &shardstates.ShardCommitDposInfo{
 		TransferId:          transferId,
 		FeeAmount:           balance,
@@ -845,7 +845,7 @@ func ShardRetryCommitDpos(native *native.NativeService) ([]byte, error) {
 	sink := common.NewZeroCopySink(0)
 	shardStakeCommitParam.Serialization(sink)
 	rootShard := common.NewShardIDUnchecked(0)
-	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, shard_stake.COMMIT_DPOS, sink.Bytes())
+	native.NotifyRemoteShard(rootShard, utils.ShardStakeAddress, 0, shard_stake.COMMIT_DPOS, sink.Bytes())
 	return utils.BYTE_TRUE, nil
 }
 

--- a/smartcontract/service/native/shardping/shardping.go
+++ b/smartcontract/service/native/shardping/shardping.go
@@ -80,7 +80,7 @@ func SendShardPingTest(native *native.NativeService) ([]byte, error) {
 	}
 
 	// send ping
-	native.NotifyRemoteShard(params.ToShard, common.ADDRESS_EMPTY, 0, "", common.SerializeToBytes(pingEvt))
+	native.NotifyRemoteShard(params.ToShard, common.ADDRESS_EMPTY, 20000, "", common.SerializeToBytes(pingEvt))
 
 	return utils.BYTE_TRUE, nil
 }

--- a/smartcontract/service/native/shardping/shardping.go
+++ b/smartcontract/service/native/shardping/shardping.go
@@ -80,7 +80,7 @@ func SendShardPingTest(native *native.NativeService) ([]byte, error) {
 	}
 
 	// send ping
-	native.NotifyRemoteShard(params.ToShard, common.ADDRESS_EMPTY, "", common.SerializeToBytes(pingEvt))
+	native.NotifyRemoteShard(params.ToShard, common.ADDRESS_EMPTY, 0, "", common.SerializeToBytes(pingEvt))
 
 	return utils.BYTE_TRUE, nil
 }

--- a/smartcontract/service/neovm/config.go
+++ b/smartcontract/service/neovm/config.go
@@ -103,6 +103,7 @@ var (
 
 	RUNTIME_GETTIME_NAME             = "System.Runtime.GetTime"
 	RUNTIME_CHECKWITNESS_NAME        = "System.Runtime.CheckWitness"
+	RUNTIME_CHECKSHARDCALL_NAME      = "System.Runtime.CheckShardCall"
 	RUNTIME_NOTIFY_NAME              = "System.Runtime.Notify"
 	RUNTIME_LOG_NAME                 = "System.Runtime.Log"
 	RUNTIME_GETTRIGGER_NAME          = "System.Runtime.GetTrigger"
@@ -111,7 +112,6 @@ var (
 	RUNTIME_BASE58TOADDRESS_NAME     = "Ontology.Runtime.Base58ToAddress"
 	RUNTIME_ADDRESSTOBASE58_NAME     = "Ontology.Runtime.AddressToBase58"
 	RUNTIME_GETCURRENTBLOCKHASH_NAME = "Ontology.Runtime.GetCurrentBlockHash"
-	RUNTIME_GETREMAINGAS_NAME        = "Ontology.Runtime.GetRemainGas"
 
 	NATIVE_INVOKE_NAME = "Ontology.Native.Invoke"
 

--- a/smartcontract/service/neovm/config.go
+++ b/smartcontract/service/neovm/config.go
@@ -78,7 +78,9 @@ var (
 	HEADER_GETNEXTCONSENSUS_NAME = "Ontology.Header.GetNextConsensus"
 	HEADER_GETMERKLEROOT_NAME    = "Ontology.Header.GetMerkleRoot"
 
-	SHARD_GET_SHARD_ID_NAME = "Ontology.Shard.GetShardId"
+	SHARD_GET_SHARD_ID_NAME        = "Ontology.Shard.GetShardId"
+	SHARD_NOTIFY_REMOTE_SHARD_NAME = "Ontology.Shard.NotifyRemoteShard"
+	SHARD_INVOKE_REMOTE_SHARD_NAME = "Ontology.Shard.InvokeRemoteShard"
 
 	TRANSACTION_GETHASH_NAME       = "System.Transaction.GetHash"
 	TRANSACTION_GETTYPE_NAME       = "Ontology.Transaction.GetType"
@@ -109,6 +111,7 @@ var (
 	RUNTIME_BASE58TOADDRESS_NAME     = "Ontology.Runtime.Base58ToAddress"
 	RUNTIME_ADDRESSTOBASE58_NAME     = "Ontology.Runtime.AddressToBase58"
 	RUNTIME_GETCURRENTBLOCKHASH_NAME = "Ontology.Runtime.GetCurrentBlockHash"
+	RUNTIME_GETREMAINGAS_NAME        = "Ontology.Runtime.GetRemainGas"
 
 	NATIVE_INVOKE_NAME = "Ontology.Native.Invoke"
 

--- a/smartcontract/service/neovm/neovm_service.go
+++ b/smartcontract/service/neovm/neovm_service.go
@@ -72,6 +72,7 @@ var (
 		CONTRACT_GETSCRIPT_NAME:              {Execute: ContractGetCode, Validator: validatorGetCode},
 		RUNTIME_GETTIME_NAME:                 {Execute: RuntimeGetTime},
 		RUNTIME_CHECKWITNESS_NAME:            {Execute: RuntimeCheckWitness, Validator: validatorCheckWitness},
+		RUNTIME_CHECKSHARDCALL_NAME:          {Execute: RuntimeCheckShardCall, Validator: validatorCheckShardCall},
 		RUNTIME_NOTIFY_NAME:                  {Execute: RuntimeNotify, Validator: validatorNotify},
 		RUNTIME_LOG_NAME:                     {Execute: RuntimeLog, Validator: validatorLog},
 		RUNTIME_GETTRIGGER_NAME:              {Execute: RuntimeGetTrigger},
@@ -92,7 +93,6 @@ var (
 		RUNTIME_BASE58TOADDRESS_NAME:     {Execute: RuntimeBase58ToAddress},
 		RUNTIME_ADDRESSTOBASE58_NAME:     {Execute: RuntimeAddressToBase58},
 		RUNTIME_GETCURRENTBLOCKHASH_NAME: {Execute: RuntimeGetCurrentBlockHash},
-		RUNTIME_GETREMAINGAS_NAME:        {Execute: RuntimeGetRemainGas},
 	}
 )
 
@@ -114,7 +114,7 @@ var (
 )
 
 type (
-	Execute   func(service *NeoVmService, engine *vm.ExecutionEngine) error
+	Execute func(service *NeoVmService, engine *vm.ExecutionEngine) error
 	Validator func(engine *vm.ExecutionEngine) error
 )
 

--- a/smartcontract/service/neovm/neovm_service.go
+++ b/smartcontract/service/neovm/neovm_service.go
@@ -62,6 +62,8 @@ var (
 		TRANSACTION_GETTYPE_NAME:             {Execute: TransactionGetType, Validator: validatorTransaction},
 		TRANSACTION_GETATTRIBUTES_NAME:       {Execute: TransactionGetAttributes, Validator: validatorTransaction},
 		SHARD_GET_SHARD_ID_NAME:              {Execute: ShardGetShardId},
+		SHARD_NOTIFY_REMOTE_SHARD_NAME:       {Execute: NotifyRemoteShard},
+		SHARD_INVOKE_REMOTE_SHARD_NAME:       {Execute: InvokeRemoteShard},
 		CONTRACT_CREATE_NAME:                 {Execute: ContractCreate},
 		CONTRACT_MIGRATE_NAME:                {Execute: ContractMigrate},
 		CONTRACT_SET_META_DATA_NAME:          {Execute: InitMetaData},
@@ -90,6 +92,7 @@ var (
 		RUNTIME_BASE58TOADDRESS_NAME:     {Execute: RuntimeBase58ToAddress},
 		RUNTIME_ADDRESSTOBASE58_NAME:     {Execute: RuntimeAddressToBase58},
 		RUNTIME_GETCURRENTBLOCKHASH_NAME: {Execute: RuntimeGetCurrentBlockHash},
+		RUNTIME_GETREMAINGAS_NAME:        {Execute: RuntimeGetRemainGas},
 	}
 )
 

--- a/smartcontract/service/neovm/neovm_service.go
+++ b/smartcontract/service/neovm/neovm_service.go
@@ -114,7 +114,7 @@ var (
 )
 
 type (
-	Execute func(service *NeoVmService, engine *vm.ExecutionEngine) error
+	Execute   func(service *NeoVmService, engine *vm.ExecutionEngine) error
 	Validator func(engine *vm.ExecutionEngine) error
 )
 

--- a/smartcontract/service/neovm/runtime.go
+++ b/smartcontract/service/neovm/runtime.go
@@ -162,6 +162,11 @@ func RuntimeGetCurrentBlockHash(service *NeoVmService, engine *vm.ExecutionEngin
 	return nil
 }
 
+func RuntimeGetRemainGas(service *NeoVmService, engine *vm.ExecutionEngine) error {
+	vm.PushData(engine, service.ContextRef.GetRemainGas())
+	return nil
+}
+
 func SerializeStackItem(item vmtypes.StackItems) ([]byte, error) {
 	if CircularRefAndDepthDetection(item) {
 		return nil, errors.NewErr("runtime serialize: can not serialize circular reference data")

--- a/smartcontract/service/neovm/runtime.go
+++ b/smartcontract/service/neovm/runtime.go
@@ -20,6 +20,7 @@ package neovm
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
@@ -64,6 +65,19 @@ func RuntimeCheckWitness(service *NeoVmService, engine *vm.ExecutionEngine) erro
 	}
 
 	vm.PushData(engine, result)
+	return nil
+}
+
+func RuntimeCheckShardCall(service *NeoVmService, engine *vm.ExecutionEngine) error {
+	shardId, err := vm.PopBigInt(engine)
+	if err != nil {
+		return err
+	}
+	shard, err := common.NewShardID(shardId.Uint64())
+	if err != nil {
+		return fmt.Errorf("param invalid")
+	}
+	vm.PushData(engine, service.ContextRef.CheckCallShard(shard))
 	return nil
 }
 
@@ -159,11 +173,6 @@ func RuntimeAddressToBase58(service *NeoVmService, engine *vm.ExecutionEngine) e
 
 func RuntimeGetCurrentBlockHash(service *NeoVmService, engine *vm.ExecutionEngine) error {
 	vm.PushData(engine, service.BlockHash.ToArray())
-	return nil
-}
-
-func RuntimeGetRemainGas(service *NeoVmService, engine *vm.ExecutionEngine) error {
-	vm.PushData(engine, service.ContextRef.GetRemainGas())
 	return nil
 }
 

--- a/smartcontract/service/neovm/shard.go
+++ b/smartcontract/service/neovm/shard.go
@@ -67,7 +67,7 @@ func NotifyRemoteShard(service *NeoVmService, engine *vm.ExecutionEngine) error 
 }
 
 func InvokeRemoteShard(service *NeoVmService, engine *vm.ExecutionEngine) error {
-	if vm.EvaluationStackCount(engine) < 5 {
+	if vm.EvaluationStackCount(engine) < 4 {
 		return fmt.Errorf("too few input parameters")
 	}
 	shardId, err := vm.PopBigInt(engine)
@@ -95,7 +95,7 @@ func InvokeRemoteShard(service *NeoVmService, engine *vm.ExecutionEngine) error 
 		return fmt.Errorf("read args failed, err: %s", err)
 	}
 	_, err = service.ContextRef.InvokeRemoteShard(target, contract, string(method), args)
-	if err != nil {
+	if err == nil {
 		vm.PushData(engine, true)
 	}
 	return err

--- a/smartcontract/service/neovm/shard.go
+++ b/smartcontract/service/neovm/shard.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/ontio/ontology/common"
 	vm "github.com/ontio/ontology/vm/neovm"
+	"math/big"
 )
 
 // ShardGetShardId push shardId to vm stack
@@ -52,6 +53,9 @@ func NotifyRemoteShard(service *NeoVmService, engine *vm.ExecutionEngine) error 
 	fee, err := vm.PopBigInt(engine)
 	if err != nil {
 		return fmt.Errorf("read fee failed, err: %s", err)
+	}
+	if fee.Cmp(big.NewInt(0)) <= 0 {
+		return fmt.Errorf("fee must larger than 0")
 	}
 	method, err := vm.PopByteArray(engine)
 	if err != nil {

--- a/smartcontract/service/neovm/shard.go
+++ b/smartcontract/service/neovm/shard.go
@@ -18,6 +18,8 @@
 package neovm
 
 import (
+	"fmt"
+	"github.com/ontio/ontology/common"
 	vm "github.com/ontio/ontology/vm/neovm"
 )
 
@@ -25,4 +27,76 @@ import (
 func ShardGetShardId(service *NeoVmService, engine *vm.ExecutionEngine) error {
 	vm.PushData(engine, service.ShardID.ToUint64())
 	return nil
+}
+
+func NotifyRemoteShard(service *NeoVmService, engine *vm.ExecutionEngine) error {
+	if vm.EvaluationStackCount(engine) < 5 {
+		return fmt.Errorf("too few input parameters")
+	}
+	shardId, err := vm.PopBigInt(engine)
+	if err != nil {
+		return fmt.Errorf("read shardId failed, err: %s", err)
+	}
+	target, err := common.NewShardID(shardId.Uint64())
+	if err != nil {
+		return fmt.Errorf("parse shardId failed, err: %s", err)
+	}
+	addr, err := vm.PopByteArray(engine)
+	if err != nil {
+		return fmt.Errorf("read dest contract failed, err: %s", err)
+	}
+	contract, err := common.AddressParseFromBytes(addr)
+	if err != nil {
+		return fmt.Errorf("parse dest contract failed, err: %s", err)
+	}
+	fee, err := vm.PopBigInt(engine)
+	if err != nil {
+		return fmt.Errorf("read fee failed, err: %s", err)
+	}
+	method, err := vm.PopByteArray(engine)
+	if err != nil {
+		return fmt.Errorf("read method failed, err: %s", err)
+	}
+	args, err := vm.PopByteArray(engine)
+	if err != nil {
+		return fmt.Errorf("read args failed, err: %s", err)
+	}
+	service.ContextRef.NotifyRemoteShard(target, contract, fee.Uint64(), string(method), args)
+	vm.PushData(engine, true)
+	return nil
+}
+
+func InvokeRemoteShard(service *NeoVmService, engine *vm.ExecutionEngine) error {
+	if vm.EvaluationStackCount(engine) < 5 {
+		return fmt.Errorf("too few input parameters")
+	}
+	shardId, err := vm.PopBigInt(engine)
+	if err != nil {
+		return fmt.Errorf("read shardId failed, err: %s", err)
+	}
+	target, err := common.NewShardID(shardId.Uint64())
+	if err != nil {
+		return fmt.Errorf("parse shardId failed, err: %s", err)
+	}
+	addr, err := vm.PopByteArray(engine)
+	if err != nil {
+		return fmt.Errorf("read dest contract failed, err: %s", err)
+	}
+	contract, err := common.AddressParseFromBytes(addr)
+	if err != nil {
+		return fmt.Errorf("parse dest contract failed, err: %s", err)
+	}
+	method, err := vm.PopByteArray(engine)
+	if err != nil {
+		return fmt.Errorf("read method failed, err: %s", err)
+	}
+	args, err := vm.PopByteArray(engine)
+	if err != nil {
+		return fmt.Errorf("read args failed, err: %s", err)
+	}
+	_, err = service.ContextRef.InvokeRemoteShard(target, contract, string(method), args)
+	if err != nil {
+		vm.PushData(engine, true)
+	}
+	return err
 }

--- a/smartcontract/service/neovm/validators.go
+++ b/smartcontract/service/neovm/validators.go
@@ -160,6 +160,13 @@ func validatorCheckWitness(engine *vm.ExecutionEngine) error {
 	return nil
 }
 
+func validatorCheckShardCall(engine *vm.ExecutionEngine) error {
+	if vm.EvaluationStackCount(engine) < 1 {
+		return errors.NewErr("[validatorCheckShardCall] Too few input parameters ")
+	}
+	return nil
+}
+
 func validatorNotify(engine *vm.ExecutionEngine) error {
 	if vm.EvaluationStackCount(engine) < 1 {
 		return errors.NewErr("[validatorNotify] Too few input parameters ")

--- a/smartcontract/testsuite/shard_flow_test.go
+++ b/smartcontract/testsuite/shard_flow_test.go
@@ -106,7 +106,7 @@ func TestShardFlowPattern1(t *testing.T) {
 	).SubCmd(
 		NewInvokeCommand(sid(1), &GreetCommand{}),
 	).SubCmd(
-		NewInvokeCommand(sid(2), NewNotifyCommand(sid(3), &GreetCommand{})),
+		NewInvokeCommand(sid(2), NewNotifyCommand(sid(3), 200000, &GreetCommand{})),
 	)
 
 	// 2 req, 2 rep, 2 prep, 2 preped, 2 commit, 1 notify = 11
@@ -118,9 +118,9 @@ func TestShardFlowPattern2(t *testing.T) {
 	//        -> invoke shard2 -> notify shard3
 	// 	      -> invoke shard1
 	flow := MutliCommand{}.SubCmd(
-		NewNotifyCommand(sid(3), &GreetCommand{}),
+		NewNotifyCommand(sid(3), 200000, &GreetCommand{}),
 	).SubCmd(
-		NewInvokeCommand(sid(2), NewNotifyCommand(sid(3), &GreetCommand{})),
+		NewInvokeCommand(sid(2), NewNotifyCommand(sid(3), 180000, &GreetCommand{})),
 	).SubCmd(
 		NewInvokeCommand(sid(1), &GreetCommand{}),
 	)
@@ -132,7 +132,7 @@ func TestShardFlowPattern2(t *testing.T) {
 func TestShardFlowPattern3(t *testing.T) {
 	// shard0 -> notify2 -> invoke3
 	flow := MutliCommand{}.SubCmd(
-		NewNotifyCommand(sid(2), NewInvokeCommand(sid(3), &GreetCommand{})),
+		NewNotifyCommand(sid(2), 200000, NewInvokeCommand(sid(3), &GreetCommand{})),
 	)
 
 	// 1 notify, 1 req, 1 rep, 1 prep, 1 preped, 1 commit = 6
@@ -142,8 +142,8 @@ func TestShardFlowPattern3(t *testing.T) {
 func TestShardFlowPattern4(t *testing.T) {
 	// shard0 -> notify2 -> invoke3 -> notify4 -> invoke5
 	flow := MutliCommand{}.SubCmd(
-		NewNotifyCommand(sid(2), NewInvokeCommand(sid(3),
-			NewNotifyCommand(sid(4), NewInvokeCommand(sid(5), &GreetCommand{})))),
+		NewNotifyCommand(sid(2), 200000, NewInvokeCommand(sid(3),
+			NewNotifyCommand(sid(4), 100000, NewInvokeCommand(sid(5), &GreetCommand{})))),
 	)
 
 	// 2 notify, 2 req, 2 rep, 2 prep, 2 preped, 2 commit = 12

--- a/smartcontract/testsuite/suite.go
+++ b/smartcontract/testsuite/suite.go
@@ -112,7 +112,7 @@ func ExecuteShardCommand(native *native.NativeService, command ShardCommand) ([]
 			result = append(result, res...)
 		}
 	case *NotifyCommand:
-		native.NotifyRemoteShard(cmd.Target, cont, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
+		native.NotifyRemoteShard(cmd.Target, cont, 0, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
 	case *InvokeCommand:
 		res, err := native.InvokeRemoteShard(cmd.Target, cont, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
 		if err != nil {
@@ -150,7 +150,7 @@ func RemoteNotifyPing(native *native.NativeService) ([]byte, error) {
 	sink.WriteString(fmt.Sprintf("hello from shard: %d", native.ShardID.ToUint64()))
 
 	cont := native.ContextRef.CurrentContext().ContractAddress
-	native.NotifyRemoteShard(ShardB, cont, "handlePing", sink.Bytes())
+	native.NotifyRemoteShard(ShardB, cont, 0, "handlePing", sink.Bytes())
 
 	return utils.BYTE_TRUE, nil
 }

--- a/smartcontract/testsuite/suite.go
+++ b/smartcontract/testsuite/suite.go
@@ -112,7 +112,7 @@ func ExecuteShardCommand(native *native.NativeService, command ShardCommand) ([]
 			result = append(result, res...)
 		}
 	case *NotifyCommand:
-		native.NotifyRemoteShard(cmd.Target, cont, 20000, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
+		native.NotifyRemoteShard(cmd.Target, cont, cmd.Fee, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
 	case *InvokeCommand:
 		res, err := native.InvokeRemoteShard(cmd.Target, cont, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
 		if err != nil {

--- a/smartcontract/testsuite/suite.go
+++ b/smartcontract/testsuite/suite.go
@@ -112,7 +112,7 @@ func ExecuteShardCommand(native *native.NativeService, command ShardCommand) ([]
 			result = append(result, res...)
 		}
 	case *NotifyCommand:
-		native.NotifyRemoteShard(cmd.Target, cont, 0, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
+		native.NotifyRemoteShard(cmd.Target, cont, 20000, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
 	case *InvokeCommand:
 		res, err := native.InvokeRemoteShard(cmd.Target, cont, "executeShardCommand", EncodeShardCommandToBytes(cmd.Cmd))
 		if err != nil {
@@ -150,7 +150,7 @@ func RemoteNotifyPing(native *native.NativeService) ([]byte, error) {
 	sink.WriteString(fmt.Sprintf("hello from shard: %d", native.ShardID.ToUint64()))
 
 	cont := native.ContextRef.CurrentContext().ContractAddress
-	native.NotifyRemoteShard(ShardB, cont, 0, "handlePing", sink.Bytes())
+	native.NotifyRemoteShard(ShardB, cont, 20000, "handlePing", sink.Bytes())
 
 	return utils.BYTE_TRUE, nil
 }


### PR DESCRIPTION
1. adapt x-shard notify and invoke to runtime api, and notify interface need user pass ```fee``` param;
2. disable x-shard call native contract straightly except while native contract is caller;
3. optimize contract invoke cli;
4. add ```Fee``` field to NotifyCommand at tset suite.
