### PR TITLE
add omit block height in transaction list

### DIFF
--- a/http/base/common/common.go
+++ b/http/base/common/common.go
@@ -264,7 +264,9 @@ func GetBlockInfo(block *types.Block) BlockInfo {
 
 	trans := make([]*Transactions, len(block.Transactions))
 	for i := 0; i < len(block.Transactions); i++ {
-		trans[i] = TransArryByteToHexString(block.Transactions[i])
+		tran := TransArryByteToHexString(block.Transactions[i])
+		tran.Height = block.Header.Height
+		trans[i] = tran
 	}
 
 	b := BlockInfo{


### PR DESCRIPTION
Currently, the RESTful and RPC interface omit block height in transaction list.

For example, [this transaction](http://dappnode1.ont.io:20334/api/v1/block/details/height/65)'s block height equals to `0` in RESTful interface:

![image](https://user-images.githubusercontent.com/18191964/63409649-27604c80-c424-11e9-8e64-238f6224e440.png)

In fact, this transaction included in block in height of 65.