### PR TITLE
support address type in sigsvr

### DIFF
--- a/cmd/utils/params.go
+++ b/cmd/utils/params.go
@@ -21,10 +21,10 @@ package utils
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/ontio/ontology/common"
 	"reflect"
 	"strconv"
 	"strings"
-	"github.com/ontio/ontology/common"
 )
 
 const (
@@ -197,11 +197,11 @@ func parseRawParamValue(pType string, pValue string) (interface{}, error) {
 			return nil, fmt.Errorf("parse boolean param:%s failed", pValue)
 		}
 	case PARAM_TYPE_ADDRESS:
-		address,err := common.AddressFromBase58(pValue)
-		if err != nil{
-			return nil,fmt.Errorf("parse address param:%s failed",pValue)
+		address, err := common.AddressFromBase58(pValue)
+		if err != nil {
+			return nil, fmt.Errorf("parse address param:%s failed", pValue)
 		}
-		return address[:],nil
+		return address[:], nil
 	default:
 		return nil, fmt.Errorf("unspport param type:%s", pType)
 	}

--- a/cmd/utils/params.go
+++ b/cmd/utils/params.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"github.com/ontio/ontology/common"
 )
 
 const (
@@ -34,6 +35,7 @@ const (
 	PARAM_TYPE_STRING     = "string"
 	PARAM_TYPE_INTEGER    = "int"
 	PARAM_TYPE_BOOLEAN    = "bool"
+	PARAM_TYPE_ADDRESS    = "address"
 	PARAM_LEFT_BRACKET    = "["
 	PARAM_RIGHT_BRACKET   = "]"
 	PARAM_ESC_CHAR        = `/`
@@ -194,6 +196,12 @@ func parseRawParamValue(pType string, pValue string) (interface{}, error) {
 		default:
 			return nil, fmt.Errorf("parse boolean param:%s failed", pValue)
 		}
+	case PARAM_TYPE_ADDRESS:
+		address,err := common.AddressFromBase58(pValue)
+		if err != nil{
+			return nil,fmt.Errorf("parse address param:%s failed",pValue)
+		}
+		return address[:],nil
 	default:
 		return nil, fmt.Errorf("unspport param type:%s", pType)
 	}

--- a/consensus/vbft/peer_pool.go
+++ b/consensus/vbft/peer_pool.go
@@ -51,12 +51,12 @@ type PeerPool struct {
 
 func NewPeerPool(maxSize int, server *Server) *PeerPool {
 	return &PeerPool{
-		maxSize: maxSize,
-		server:  server,
-		configs: make(map[uint32]*vconfig.PeerConfig),
-		IDMap:   make(map[string]uint32),
-		P2pMap:  make(map[uint32]uint64),
-		peers:   make(map[uint32]*Peer),
+		maxSize:                maxSize,
+		server:                 server,
+		configs:                make(map[uint32]*vconfig.PeerConfig),
+		IDMap:                  make(map[string]uint32),
+		P2pMap:                 make(map[uint32]uint64),
+		peers:                  make(map[uint32]*Peer),
 		peerConnectionWaitings: make(map[uint32]chan struct{}),
 	}
 }

--- a/consensus/vbft/peer_pool.go
+++ b/consensus/vbft/peer_pool.go
@@ -51,12 +51,12 @@ type PeerPool struct {
 
 func NewPeerPool(maxSize int, server *Server) *PeerPool {
 	return &PeerPool{
-		maxSize:                maxSize,
-		server:                 server,
-		configs:                make(map[uint32]*vconfig.PeerConfig),
-		IDMap:                  make(map[string]uint32),
-		P2pMap:                 make(map[uint32]uint64),
-		peers:                  make(map[uint32]*Peer),
+		maxSize: maxSize,
+		server:  server,
+		configs: make(map[uint32]*vconfig.PeerConfig),
+		IDMap:   make(map[string]uint32),
+		P2pMap:  make(map[uint32]uint64),
+		peers:   make(map[uint32]*Peer),
 		peerConnectionWaitings: make(map[uint32]chan struct{}),
 	}
 }


### PR DESCRIPTION
now sigsvr only support bytearray type in neovm (oep4) transfer, add the base58 for "address" type for sigsvr