### PR TITLE
Close socket gracefully

### DIFF
--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -264,6 +264,7 @@ func VersionHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 		}
 		if !found {
 			remotePeer.Close()
+			remotePeer.Link.CloseConn()
 			log.Debug("[p2p]peer not in reserved list,close", data.Addr)
 			return
 		}
@@ -276,6 +277,7 @@ func VersionHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 		log.Warn("[p2p]the node handshake with itself", remotePeer.GetAddr())
 		p2p.SetOwnAddress(nodeAddr)
 		remotePeer.Close()
+		remotePeer.Link.CloseConn()
 		return
 	}
 
@@ -283,6 +285,7 @@ func VersionHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 	if s != msgCommon.INIT && s != msgCommon.HAND {
 		log.Warnf("[p2p]unknown status to received version,%d,%s\n", s, remotePeer.GetAddr())
 		remotePeer.Close()
+		remotePeer.Link.CloseConn()
 		return
 	}
 
@@ -297,6 +300,7 @@ func VersionHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 		ipNew, err := msgCommon.ParseIPAddr(data.Addr)
 		if err != nil {
 			remotePeer.Close()
+			remotePeer.Link.CloseConn()
 			log.Warn("[p2p]connecting peer %d ip format is wrong %s, close", version.P.Nonce, data.Addr)
 			return
 		}
@@ -317,6 +321,7 @@ func VersionHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 		} else {
 			log.Warnf("[p2p]same peer id from different addr: %s, %s close latest one", ipOld, ipNew)
 			remotePeer.Close()
+			remotePeer.Link.CloseConn()
 			return
 
 		}

--- a/p2pserver/net/netserver/netserver.go
+++ b/p2pserver/net/netserver/netserver.go
@@ -316,6 +316,7 @@ func (this *NetServer) Halt() {
 	peers := this.Np.GetNeighbors()
 	for _, p := range peers {
 		p.Close()
+		p.Link.CloseConn()
 	}
 	if this.listener != nil {
 		this.listener.Close()

--- a/p2pserver/peer/peer.go
+++ b/p2pserver/peer/peer.go
@@ -196,7 +196,7 @@ func (this *Peer) GetPort() uint16 {
 	return this.Link.GetPort()
 }
 
-//SendTo call sync link to send buffer
+//SendRaw call sync link to send buffer
 func (this *Peer) SendRaw(msgType string, msgPayload []byte) error {
 	if this.Link != nil && this.Link.Valid() {
 		return this.Link.SendRaw(msgPayload)
@@ -206,12 +206,9 @@ func (this *Peer) SendRaw(msgType string, msgPayload []byte) error {
 
 //Close halt sync connection
 func (this *Peer) Close() {
-	this.SetState(common.INACTIVITY)
-	conn := this.Link.GetConn()
 	this.connLock.Lock()
-	if conn != nil {
-		conn.Close()
-	}
+	this.SetState(common.INACTIVITY)
+	this.Link.CloseLink()
 	this.connLock.Unlock()
 }
 


### PR DESCRIPTION
don't close peer's Link directly, because this link(socket) may be used to tranfer message.

Detail
1. use a channel to indicate the close action. i.e. when we need to close Link, we close this channel.
2. Send become noop, whenever we need to send message, we first check whether the link  is valid, since we've set the close Link state to invalid, so peer.Send become noop
3. link::Rx may already sleepped. 
    if Rx has data to read, just before the next round read() we break the read loop.
    if Rx read no data and the Rx sleep forever, so the underline socket is leaked. To avoid this, we add a goroutine to close the underlinke socket in peer map: netserver.Np to ensure all the invalid peer should close its underline socket.

