### PR TITLE
Break whole loop in heartBeatService

### DIFF
--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -494,7 +494,7 @@ func (this *P2PServer) heartBeatService() {
 			this.timeout()
 		case <-this.quitHeartBeat:
 			t.Stop()
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
The break statement's intention is to quit the for loop, but what it actually break is only the select block, i.e. we still in for loop, just because the main goroutine take down so this for loop goes down as well. Since there are no logic code after the for loop, a simple return will do.