### PR TITLE
Change p2pserver connection cache from slice to set

### DIFF
--- a/p2pserver/common/set/string_set.go
+++ b/p2pserver/common/set/string_set.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package set
 
 import (

--- a/p2pserver/common/set/string_set.go
+++ b/p2pserver/common/set/string_set.go
@@ -1,0 +1,189 @@
+package set
+
+import (
+	"reflect"
+	"sort"
+)
+
+type Empty struct{}
+
+// sets.String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
+type String map[string]Empty
+
+// NewString creates a String from a list of values.
+func NewString(items ...string) String {
+	ss := String{}
+	ss.Insert(items...)
+	return ss
+}
+
+// StringKeySet creates a String from a keys of a map[string](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func StringKeySet(theMap interface{}) String {
+	v := reflect.ValueOf(theMap)
+	ret := String{}
+
+	for _, keyValue := range v.MapKeys() {
+		ret.Insert(keyValue.Interface().(string))
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s String) Insert(items ...string) String {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+	return s
+}
+
+// Delete removes all items from the set.
+func (s String) Delete(items ...string) String {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s String) Has(item string) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s String) HasAll(items ...string) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s String) HasAny(items ...string) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s String) Difference(s2 String) String {
+	result := NewString()
+	for key := range s {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 String) Union(s2 String) String {
+	result := NewString()
+	for key := range s1 {
+		result.Insert(key)
+	}
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 String) Intersection(s2 String) String {
+	var walk, other String
+	result := NewString()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 String) IsSuperset(s2 String) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 String) Equal(s2 String) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+type sortableSliceOfString []string
+
+func (s sortableSliceOfString) Len() int           { return len(s) }
+func (s sortableSliceOfString) Less(i, j int) bool { return lessString(s[i], s[j]) }
+func (s sortableSliceOfString) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// List returns the contents as a sorted string slice.
+func (s String) List() []string {
+	res := make(sortableSliceOfString, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return []string(res)
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s String) UnsortedList() []string {
+	res := make([]string, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// Returns a single element from the set.
+func (s String) PopAny() (string, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue string
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s String) Len() int {
+	return len(s)
+}
+
+func lessString(lhs, rhs string) bool {
+	return lhs < rhs
+}

--- a/p2pserver/common/set/string_set.go
+++ b/p2pserver/common/set/string_set.go
@@ -20,26 +20,25 @@ package set
 
 import (
 	"reflect"
-	"sort"
 )
 
-type Empty struct{}
+type empty struct{}
 
-// sets.String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
-type String map[string]Empty
+// StringSet is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
+type StringSet map[string]empty
 
-// NewString creates a String from a list of values.
-func NewString(items ...string) String {
-	ss := String{}
+// NewStringSet creates a StringSet from a list of values.
+func NewStringSet(items ...string) StringSet {
+	ss := StringSet{}
 	ss.Insert(items...)
 	return ss
 }
 
-// StringKeySet creates a String from a keys of a map[string](? extends interface{}).
+// StringKeySet creates a StringSet from a keys of a map[string](? extends interface{}).
 // If the value passed in is not actually a map, this will panic.
-func StringKeySet(theMap interface{}) String {
+func StringKeySet(theMap interface{}) StringSet {
 	v := reflect.ValueOf(theMap)
-	ret := String{}
+	ret := StringSet{}
 
 	for _, keyValue := range v.MapKeys() {
 		ret.Insert(keyValue.Interface().(string))
@@ -48,15 +47,15 @@ func StringKeySet(theMap interface{}) String {
 }
 
 // Insert adds items to the set.
-func (s String) Insert(items ...string) String {
+func (s StringSet) Insert(items ...string) StringSet {
 	for _, item := range items {
-		s[item] = Empty{}
+		s[item] = empty{}
 	}
 	return s
 }
 
 // Delete removes all items from the set.
-func (s String) Delete(items ...string) String {
+func (s StringSet) Delete(items ...string) StringSet {
 	for _, item := range items {
 		delete(s, item)
 	}
@@ -64,144 +63,12 @@ func (s String) Delete(items ...string) String {
 }
 
 // Has returns true if and only if item is contained in the set.
-func (s String) Has(item string) bool {
+func (s StringSet) Has(item string) bool {
 	_, contained := s[item]
 	return contained
 }
 
-// HasAll returns true if and only if all items are contained in the set.
-func (s String) HasAll(items ...string) bool {
-	for _, item := range items {
-		if !s.Has(item) {
-			return false
-		}
-	}
-	return true
-}
-
-// HasAny returns true if any items are contained in the set.
-func (s String) HasAny(items ...string) bool {
-	for _, item := range items {
-		if s.Has(item) {
-			return true
-		}
-	}
-	return false
-}
-
-// Difference returns a set of objects that are not in s2
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
-func (s String) Difference(s2 String) String {
-	result := NewString()
-	for key := range s {
-		if !s2.Has(key) {
-			result.Insert(key)
-		}
-	}
-	return result
-}
-
-// Union returns a new set which includes items in either s1 or s2.
-// For example:
-// s1 = {a1, a2}
-// s2 = {a3, a4}
-// s1.Union(s2) = {a1, a2, a3, a4}
-// s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 String) Union(s2 String) String {
-	result := NewString()
-	for key := range s1 {
-		result.Insert(key)
-	}
-	for key := range s2 {
-		result.Insert(key)
-	}
-	return result
-}
-
-// Intersection returns a new set which includes the item in BOTH s1 and s2
-// For example:
-// s1 = {a1, a2}
-// s2 = {a2, a3}
-// s1.Intersection(s2) = {a2}
-func (s1 String) Intersection(s2 String) String {
-	var walk, other String
-	result := NewString()
-	if s1.Len() < s2.Len() {
-		walk = s1
-		other = s2
-	} else {
-		walk = s2
-		other = s1
-	}
-	for key := range walk {
-		if other.Has(key) {
-			result.Insert(key)
-		}
-	}
-	return result
-}
-
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 String) IsSuperset(s2 String) bool {
-	for item := range s2 {
-		if !s1.Has(item) {
-			return false
-		}
-	}
-	return true
-}
-
-// Equal returns true if and only if s1 is equal (as a set) to s2.
-// Two sets are equal if their membership is identical.
-// (In practice, this means same elements, order doesn't matter)
-func (s1 String) Equal(s2 String) bool {
-	return len(s1) == len(s2) && s1.IsSuperset(s2)
-}
-
-type sortableSliceOfString []string
-
-func (s sortableSliceOfString) Len() int           { return len(s) }
-func (s sortableSliceOfString) Less(i, j int) bool { return lessString(s[i], s[j]) }
-func (s sortableSliceOfString) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
-// List returns the contents as a sorted string slice.
-func (s String) List() []string {
-	res := make(sortableSliceOfString, 0, len(s))
-	for key := range s {
-		res = append(res, key)
-	}
-	sort.Sort(res)
-	return []string(res)
-}
-
-// UnsortedList returns the slice with contents in random order.
-func (s String) UnsortedList() []string {
-	res := make([]string, 0, len(s))
-	for key := range s {
-		res = append(res, key)
-	}
-	return res
-}
-
-// Returns a single element from the set.
-func (s String) PopAny() (string, bool) {
-	for key := range s {
-		s.Delete(key)
-		return key, true
-	}
-	var zeroValue string
-	return zeroValue, false
-}
-
 // Len returns the size of the set.
-func (s String) Len() int {
+func (s StringSet) Len() int {
 	return len(s)
-}
-
-func lessString(lhs, rhs string) bool {
-	return lhs < rhs
 }

--- a/p2pserver/common/set/string_set_test.go
+++ b/p2pserver/common/set/string_set_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package set
 
 import (

--- a/p2pserver/common/set/string_set_test.go
+++ b/p2pserver/common/set/string_set_test.go
@@ -15,21 +15,20 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package set
 
 import (
-	"reflect"
 	"testing"
 )
 
 func TestStringSet(t *testing.T) {
-	s := String{}
-	s2 := String{}
-	if len(s) != 0 {
+	s := StringSet{}
+	if s.Len() != 0 {
 		t.Errorf("Expected len=0: %d", len(s))
 	}
 	s.Insert("a", "b")
-	if len(s) != 2 {
+	if s.Len() != 2 {
 		t.Errorf("Expected len=2: %d", len(s))
 	}
 	s.Insert("c")
@@ -43,121 +42,37 @@ func TestStringSet(t *testing.T) {
 	if s.Has("a") {
 		t.Errorf("Unexpected contents: %#v", s)
 	}
-	s.Insert("a")
-	if s.HasAll("a", "b", "d") {
+}
+
+func TestStringSetDeleteMultiples(t *testing.T) {
+	s := StringSet{}
+	s.Insert("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete("a", "c")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has("a") {
 		t.Errorf("Unexpected contents: %#v", s)
 	}
-	if !s.HasAll("a", "b") {
-		t.Errorf("Missing contents: %#v", s)
-	}
-	s2.Insert("a", "b", "d")
-	if s.IsSuperset(s2) {
+	if s.Has("c") {
 		t.Errorf("Unexpected contents: %#v", s)
 	}
-	s2.Delete("d")
-	if !s.IsSuperset(s2) {
+	if !s.Has("b") {
 		t.Errorf("Missing contents: %#v", s)
 	}
+
 }
 
 func TestNewStringSet(t *testing.T) {
-	s := NewString("a", "b", "c")
+	s := NewStringSet("a", "b", "c")
 	if len(s) != 3 {
 		t.Errorf("Expected len=3: %d", len(s))
 	}
 	if !s.Has("a") || !s.Has("b") || !s.Has("c") {
 		t.Errorf("Unexpected contents: %#v", s)
-	}
-}
-
-func TestStringSetList(t *testing.T) {
-	s := NewString("z", "y", "x", "a")
-	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
-		t.Errorf("List gave unexpected result: %#v", s.List())
-	}
-}
-
-func TestStringUnion(t *testing.T) {
-	tests := []struct {
-		s1       String
-		s2       String
-		expected String
-	}{
-		{
-			NewString("1", "2", "3", "4"),
-			NewString("3", "4", "5", "6"),
-			NewString("1", "2", "3", "4", "5", "6"),
-		},
-		{
-			NewString("1", "2", "3", "4"),
-			NewString(),
-			NewString("1", "2", "3", "4"),
-		},
-		{
-			NewString(),
-			NewString("1", "2", "3", "4"),
-			NewString("1", "2", "3", "4"),
-		},
-		{
-			NewString(),
-			NewString(),
-			NewString(),
-		},
-	}
-
-	for _, test := range tests {
-		union := test.s1.Union(test.s2)
-		if union.Len() != test.expected.Len() {
-			t.Errorf("Expected union.Len()=%d but got %d", test.expected.Len(), union.Len())
-		}
-
-		if !union.Equal(test.expected) {
-			t.Errorf("Expected union.Equal(expected) but not true.  union:%v expected:%v", union.List(), test.expected.List())
-		}
-	}
-}
-
-func TestStringIntersection(t *testing.T) {
-	tests := []struct {
-		s1       String
-		s2       String
-		expected String
-	}{
-		{
-			NewString("1", "2", "3", "4"),
-			NewString("3", "4", "5", "6"),
-			NewString("3", "4"),
-		},
-		{
-			NewString("1", "2", "3", "4"),
-			NewString("1", "2", "3", "4"),
-			NewString("1", "2", "3", "4"),
-		},
-		{
-			NewString("1", "2", "3", "4"),
-			NewString(),
-			NewString(),
-		},
-		{
-			NewString(),
-			NewString("1", "2", "3", "4"),
-			NewString(),
-		},
-		{
-			NewString(),
-			NewString(),
-			NewString(),
-		},
-	}
-
-	for _, test := range tests {
-		intersection := test.s1.Intersection(test.s2)
-		if intersection.Len() != test.expected.Len() {
-			t.Errorf("Expected intersection.Len()=%d but got %d", test.expected.Len(), intersection.Len())
-		}
-
-		if !intersection.Equal(test.expected) {
-			t.Errorf("Expected intersection.Equal(expected) but not true.  intersection:%v expected:%v", intersection.List(), test.expected.List())
-		}
 	}
 }

--- a/p2pserver/common/set/string_set_test.go
+++ b/p2pserver/common/set/string_set_test.go
@@ -1,0 +1,146 @@
+package set
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStringSet(t *testing.T) {
+	s := String{}
+	s2 := String{}
+	if len(s) != 0 {
+		t.Errorf("Expected len=0: %d", len(s))
+	}
+	s.Insert("a", "b")
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	s.Insert("c")
+	if s.Has("d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("a") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s.Delete("a")
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert("a")
+	if s.HasAll("a", "b", "d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll("a", "b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert("a", "b", "d")
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete("d")
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestNewStringSet(t *testing.T) {
+	s := NewString("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	if !s.Has("a") || !s.Has("b") || !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestStringSetList(t *testing.T) {
+	s := NewString("z", "y", "x", "a")
+	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
+		t.Errorf("List gave unexpected result: %#v", s.List())
+	}
+}
+
+func TestStringUnion(t *testing.T) {
+	tests := []struct {
+		s1       String
+		s2       String
+		expected String
+	}{
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("3", "4", "5", "6"),
+			NewString("1", "2", "3", "4", "5", "6"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString(),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString(),
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString(),
+			NewString(),
+			NewString(),
+		},
+	}
+
+	for _, test := range tests {
+		union := test.s1.Union(test.s2)
+		if union.Len() != test.expected.Len() {
+			t.Errorf("Expected union.Len()=%d but got %d", test.expected.Len(), union.Len())
+		}
+
+		if !union.Equal(test.expected) {
+			t.Errorf("Expected union.Equal(expected) but not true.  union:%v expected:%v", union.List(), test.expected.List())
+		}
+	}
+}
+
+func TestStringIntersection(t *testing.T) {
+	tests := []struct {
+		s1       String
+		s2       String
+		expected String
+	}{
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("3", "4", "5", "6"),
+			NewString("3", "4"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString(),
+			NewString(),
+		},
+		{
+			NewString(),
+			NewString("1", "2", "3", "4"),
+			NewString(),
+		},
+		{
+			NewString(),
+			NewString(),
+			NewString(),
+		},
+	}
+
+	for _, test := range tests {
+		intersection := test.s1.Intersection(test.s2)
+		if intersection.Len() != test.expected.Len() {
+			t.Errorf("Expected intersection.Len()=%d but got %d", test.expected.Len(), intersection.Len())
+		}
+
+		if !intersection.Equal(test.expected) {
+			t.Errorf("Expected intersection.Equal(expected) but not true.  intersection:%v expected:%v", intersection.List(), test.expected.List())
+		}
+	}
+}

--- a/p2pserver/net/netserver/netserver.go
+++ b/p2pserver/net/netserver/netserver.go
@@ -66,19 +66,19 @@ type NetServer struct {
 //InConnectionRecord include all addr connected
 type InConnectionRecord struct {
 	sync.RWMutex
-	InConnectingAddrs set.String
+	InConnectingAddrs set.StringSet
 }
 
 //OutConnectionRecord include all addr accepted
 type OutConnectionRecord struct {
 	sync.RWMutex
-	OutConnectingAddrs set.String
+	OutConnectingAddrs set.StringSet
 }
 
 //connectingNodes include all addr in connecting state
 type connectingNodes struct {
 	sync.RWMutex
-	ConnectingAddrs set.String
+	ConnectingAddrs set.StringSet
 }
 
 //PeerAddrMap include all addr-peer list
@@ -115,9 +115,9 @@ func (this *NetServer) init() error {
 	this.Np = &peer.NbrPeers{}
 	this.Np.Init()
 
-	this.connectingNodes.ConnectingAddrs = set.NewString()
-	this.inConnRecord.InConnectingAddrs = set.NewString()
-	this.outConnRecord.OutConnectingAddrs = set.NewString()
+	this.connectingNodes.ConnectingAddrs = set.NewStringSet()
+	this.inConnRecord.InConnectingAddrs = set.NewStringSet()
+	this.outConnRecord.OutConnectingAddrs = set.NewStringSet()
 
 	return nil
 }

--- a/p2pserver/net/netserver/netserver_test.go
+++ b/p2pserver/net/netserver/netserver_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ontio/ontology/common/log"
 	"github.com/ontio/ontology/p2pserver/common"
 	"github.com/ontio/ontology/p2pserver/peer"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -115,4 +116,72 @@ func TestNetServerNbrPeer(t *testing.T) {
 		t.Error("TestNetServerNbrPeer Get/AddPeerConsAddress error")
 	}
 
+}
+
+func TestConnectingNodeAPI(t *testing.T) {
+	a := require.New(t)
+	server := NewNetServer()
+
+	a.Equal(server.GetOutConnectingListLen(), uint(0), "fail to test GetOutConnectingListLen")
+
+	server.AddOutConnectingList("192.168.1.1:28339")
+	a.Equal(server.GetOutConnectingListLen(), uint(1), "fail to test AddOutConnectingList")
+
+	// add same
+	server.AddOutConnectingList("192.168.1.1:28339")
+	a.Equal(server.GetOutConnectingListLen(), uint(1), "fail to test AddOutConnectingList")
+
+	// add new
+	server.AddOutConnectingList("192.168.2.2:2")
+	a.Equal(server.GetOutConnectingListLen(), uint(2), "fail to test AddOutConnectingList")
+
+	// test exist
+	a.Equal(server.IsAddrFromConnecting("192.168.2.2:2"), true, "fail to test IsAddrFromConnecting")
+	a.Equal(server.IsAddrFromConnecting("192.168.2.3:3"), false, "fail to test IsAddrFromConnecting")
+
+	server.RemoveFromConnectingList("192.168.2.2:2")
+	a.Equal(server.GetOutConnectingListLen(), uint(1), "fail to test RemoveFromConnectingList")
+}
+
+
+func TestInConnAPI(t *testing.T) {
+	a := require.New(t)
+	si := NewNetServer()
+	server, ok := si.(*NetServer)
+	a.True(ok, "fail to cast P2PServer")
+
+	a.Equal(server.GetInConnRecordLen(),  int(0),  "fail to test GetInConnRecordLen")
+	server.AddInConnRecord("192.168.1.1:1024")
+	a.Equal(server.GetInConnRecordLen(), int(1), "fail to test AddInConnRecord")
+	server.AddInConnRecord("192.168.1.1:1024")
+	a.Equal(server.GetInConnRecordLen(), int(1), "fail to test GetInConnRecordLen")
+	server.AddInConnRecord("192.168.1.2:2048")
+	a.Equal(server.GetInConnRecordLen(), int(2), "fail to test AddInConnRecord")
+	server.RemoveFromInConnRecord("192.168.1.2:2048")
+	a.Equal(server.GetInConnRecordLen(), int(1), "fail to test RemoveFromInConnRecord")
+	// same IP, different port
+	server.AddInConnRecord("192.168.1.1:2048")
+	a.Equal(server.GetInConnRecordLen(), int(2), "fail to test RemoveFromInConnRecord")
+
+	a.Equal(server.GetIpCountInInConnRecord("192.168.1.1"), uint(2), "fail to test GetIpCountInInConnRecord")
+}
+
+
+func TestOutConnAPI(t *testing.T) {
+	a := require.New(t)
+	si := NewNetServer()
+	server, ok := si.(*NetServer)
+	a.True(ok, "fail to case P2PServer")
+
+	a.Equal(server.GetOutConnRecordLen(), int(0), "fail to test GetOutConnRecordLen")
+	server.AddOutConnRecord("192.168.1.1:200")
+	a.Equal(server.GetOutConnRecordLen(), int(1), "fail to test AddOutConnRecord")
+	server.AddOutConnRecord("192.168.1.1:200")
+	a.Equal(server.GetOutConnRecordLen(), int(1), "fail to test AddOutConnRecord")
+	server.AddOutConnRecord("192.168.1.1:300")
+	a.Equal(server.GetOutConnRecordLen(), int(2), "fail to test AddOutConnRecord")
+	server.RemoveFromOutConnRecord("192.168.1.1:300")
+	a.Equal(server.GetOutConnRecordLen(), int(1), "fail to test RemoveFromOutConnRecord")
+	a.Equal(server.IsAddrInOutConnRecord("192.168.1.1:300"), false, "fail to test IsAddrInOutConnRecord")
+	a.Equal(server.IsAddrInOutConnRecord("192.168.1.1:200"), true, "fail to test IsAddrInOutConnRecord")
 }

--- a/p2pserver/net/netserver/netserver_test.go
+++ b/p2pserver/net/netserver/netserver_test.go
@@ -124,12 +124,14 @@ func TestConnectingNodeAPI(t *testing.T) {
 
 	a.Equal(server.GetOutConnectingListLen(), uint(0), "fail to test GetOutConnectingListLen")
 
-	server.AddOutConnectingList("192.168.1.1:28339")
+	addOK := server.AddOutConnectingList("192.168.1.1:28339")
 	a.Equal(server.GetOutConnectingListLen(), uint(1), "fail to test AddOutConnectingList")
+	a.Equal(addOK, true, "fail to test AddOutConnectingList")
 
 	// add same
-	server.AddOutConnectingList("192.168.1.1:28339")
+	addOK = server.AddOutConnectingList("192.168.1.1:28339")
 	a.Equal(server.GetOutConnectingListLen(), uint(1), "fail to test AddOutConnectingList")
+	a.Equal(addOK, false, "fail to test AddOutConnectingList")
 
 	// add new
 	server.AddOutConnectingList("192.168.2.2:2")
@@ -143,14 +145,13 @@ func TestConnectingNodeAPI(t *testing.T) {
 	a.Equal(server.GetOutConnectingListLen(), uint(1), "fail to test RemoveFromConnectingList")
 }
 
-
 func TestInConnAPI(t *testing.T) {
 	a := require.New(t)
 	si := NewNetServer()
 	server, ok := si.(*NetServer)
 	a.True(ok, "fail to cast P2PServer")
 
-	a.Equal(server.GetInConnRecordLen(),  int(0),  "fail to test GetInConnRecordLen")
+	a.Equal(server.GetInConnRecordLen(), int(0), "fail to test GetInConnRecordLen")
 	server.AddInConnRecord("192.168.1.1:1024")
 	a.Equal(server.GetInConnRecordLen(), int(1), "fail to test AddInConnRecord")
 	server.AddInConnRecord("192.168.1.1:1024")
@@ -165,7 +166,6 @@ func TestInConnAPI(t *testing.T) {
 
 	a.Equal(server.GetIpCountInInConnRecord("192.168.1.1"), uint(2), "fail to test GetIpCountInInConnRecord")
 }
-
 
 func TestOutConnAPI(t *testing.T) {
 	a := require.New(t)


### PR DESCRIPTION
1. the time complexity of searching in slice is O(n) so change from slice to map give a better performace.
2. ConnectingNodes field in NetServer need not to export, all access to this field is from the 4 API(AddOutConnectingList/RemoveFromConnectingList/GetOutConnectingListLen/ IsAddrFromConnecting) so lowercase this field.
3. the other two cache(inConnRecord/outConnRecord) are similar with ConnectingNodes
4. Add testcase to cover those change.