### PR TITLE
Make boolean statments more readable

### DIFF
--- a/p2pserver/block_sync.go
+++ b/p2pserver/block_sync.go
@@ -846,10 +846,7 @@ func (this *BlockSyncMgr) getFlightBlockCount() int {
 
 func (this *BlockSyncMgr) isBlockOnFlight(blockHash common.Uint256) bool {
 	flightInfos := this.getFlightBlocks(blockHash)
-	if len(flightInfos) != 0 {
-		return true
-	}
-	return false
+	return len(flightInfos) != 0
 }
 
 func (this *BlockSyncMgr) getNextNode(nextBlockHeight uint32) *peer.Peer {

--- a/p2pserver/message/utils/msg_handler.go
+++ b/p2pserver/message/utils/msg_handler.go
@@ -302,8 +302,8 @@ func VersionHandle(data *msgTypes.MsgPayload, p2p p2p.P2P, pid *evtActor.PID, ar
 		}
 		if ipNew == ipOld {
 			//same id and same ip
-			n, ret := p2p.DelNbrNode(version.P.Nonce)
-			if ret == true {
+			n, delOK := p2p.DelNbrNode(version.P.Nonce)
+			if delOK {
 				log.Infof("[p2p]peer reconnect %d", version.P.Nonce, data.Addr)
 				// Close the connection and release the node source
 				n.Close()

--- a/p2pserver/net/netserver/netserver.go
+++ b/p2pserver/net/netserver/netserver.go
@@ -234,10 +234,10 @@ func (this *NetServer) Send(p *peer.Peer, msg types.Message) error {
 
 //IsPeerEstablished return the establise state of given peer`s id
 func (this *NetServer) IsPeerEstablished(p *peer.Peer) bool {
-	if p != nil {
-		return this.Np.NodeEstablished(p.GetID())
+	if p == nil {
+		return false
 	}
-	return false
+	return this.Np.NodeEstablished(p.GetID())
 }
 
 //Connect used to connect net address under sync or cons mode
@@ -267,7 +267,7 @@ func (this *NetServer) Connect(addr string) error {
 		return nil
 	}
 	this.connectLock.Lock()
-	if added := this.AddOutConnectingList(addr); added == false {
+	if addOK := this.AddOutConnectingList(addr); !addOK {
 		log.Debug("[p2p]node exist in connecting list", addr)
 	}
 	this.connectLock.Unlock()
@@ -613,10 +613,7 @@ func (this *NetServer) AddrValid(addr string) bool {
 
 //check own network address
 func (this *NetServer) IsOwnAddress(addr string) bool {
-	if addr == this.OwnAddress {
-		return true
-	}
-	return false
+	return addr == this.OwnAddress
 }
 
 //Set own network address

--- a/p2pserver/net/netserver/netserver_test.go
+++ b/p2pserver/net/netserver/netserver_test.go
@@ -63,7 +63,7 @@ func TestNewNetServer(t *testing.T) {
 		t.Error("TestNewNetServer set server height error")
 	}
 
-	if server.GetRelay() != true {
+	if !server.GetRelay() {
 		t.Error("TestNewNetServer server relay state error", server.GetRelay())
 	}
 	if server.GetServices() != 1 {
@@ -97,14 +97,14 @@ func TestNetServerNbrPeer(t *testing.T) {
 	if len(addrs) != 5 {
 		t.Error("TestNetServerNbrPeer GetNeighborAddrs error")
 	}
-	if server.NodeEstablished(0x7533345) == false {
+	if !server.NodeEstablished(0x7533345) {
 		t.Error("TestNetServerNbrPeer NodeEstablished error")
 	}
 	if server.GetPeer(0x7533345) == nil {
 		t.Error("TestNetServerNbrPeer GetPeer error")
 	}
 	p, ok := server.DelNbrNode(0x7533345)
-	if ok != true || p == nil {
+	if !ok || p == nil {
 		t.Error("TestNetServerNbrPeer DelNbrNode error")
 	}
 	if len(server.GetNeighbors()) != 4 {

--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -344,7 +344,7 @@ func (this *P2PServer) connectSeeds() {
 
 //reachMinConnection return whether net layer have enough link under different config
 func (this *P2PServer) reachMinConnection() bool {
-	if config.DefConfig.Consensus.EnableConsensus == false {
+	if !config.DefConfig.Consensus.EnableConsensus {
 		//just sync
 		return true
 	}

--- a/p2pserver/peer/nbr_peer_test.go
+++ b/p2pserver/peer/nbr_peer_test.go
@@ -57,10 +57,10 @@ func initTestNbrPeers() *NbrPeers {
 func TestNodeExisted(t *testing.T) {
 	nm := initTestNbrPeers()
 
-	if nm.NodeExisted(0x7533345) == false {
+	if !nm.NodeExisted(0x7533345) {
 		t.Fatal("0x7533345 should in nbr peers")
 	}
-	if nm.NodeExisted(0x5533345) == true {
+	if nm.NodeExisted(0x5533345) {
 		t.Fatal("0x5533345 should not in nbr peers")
 	}
 }
@@ -83,7 +83,7 @@ func TestAddNbrNode(t *testing.T) {
 	p.SetHttpInfoState(true)
 	p.Link.SetAddr("127.0.0.1")
 	nm.AddNbrNode(p)
-	if nm.NodeExisted(0x7123456) == false {
+	if !nm.NodeExisted(0x7123456) {
 		t.Fatal("0x7123456 should be added in nbr peer")
 	}
 	if len(nm.List) != 6 {
@@ -95,8 +95,8 @@ func TestDelNbrNode(t *testing.T) {
 	nm := initTestNbrPeers()
 
 	cnt := len(nm.List)
-	p, ret := nm.DelNbrNode(0x7533345)
-	if p == nil || ret != true {
+	p, delOK := nm.DelNbrNode(0x7533345)
+	if p == nil || !delOK {
 		t.Fatal("TestDelNbrNode err")
 	}
 	if len(nm.List) != cnt-1 {
@@ -113,7 +113,7 @@ func TestNodeEstablished(t *testing.T) {
 		t.Fatal("TestNodeEstablished:get peer error")
 	}
 	p.SetState(4)
-	if nm.NodeEstablished(0x7533346) == false {
+	if !nm.NodeEstablished(0x7533346) {
 		t.Fatal("TestNodeEstablished error")
 	}
 }

--- a/p2pserver/peer/nbr_peers.go
+++ b/p2pserver/peer/nbr_peers.go
@@ -41,7 +41,7 @@ func (this *NbrPeers) Broadcast(msg types.Message) {
 	this.RLock()
 	defer this.RUnlock()
 	for _, node := range this.List {
-		if node.linkState == common.ESTABLISH && node.GetRelay() == true {
+		if node.linkState == common.ESTABLISH && node.GetRelay() {
 			node.SendRaw(msg.CmdType(), sink.Bytes())
 		}
 	}
@@ -57,8 +57,8 @@ func (this *NbrPeers) NodeExisted(uid uint64) bool {
 func (this *NbrPeers) GetPeer(id uint64) *Peer {
 	this.Lock()
 	defer this.Unlock()
-	n, ok := this.List[id]
-	if ok == false {
+	n, exist := this.List[id]
+	if !exist {
 		return nil
 	}
 	return n
@@ -81,8 +81,8 @@ func (this *NbrPeers) DelNbrNode(id uint64) (*Peer, bool) {
 	this.Lock()
 	defer this.Unlock()
 
-	n, ok := this.List[id]
-	if ok == false {
+	n, exist := this.List[id]
+	if !exist {
 		return nil, false
 	}
 	delete(this.List, id)
@@ -99,16 +99,12 @@ func (this *NbrPeers) NodeEstablished(id uint64) bool {
 	this.RLock()
 	defer this.RUnlock()
 
-	n, ok := this.List[id]
-	if ok == false {
+	n, exist := this.List[id]
+	if !exist {
 		return false
 	}
 
-	if n.linkState != common.ESTABLISH {
-		return false
-	}
-
-	return true
+	return n.linkState == common.ESTABLISH
 }
 
 //GetNeighborAddrs return all establish peer address

--- a/p2pserver/peer/peer_test.go
+++ b/p2pserver/peer/peer_test.go
@@ -65,11 +65,11 @@ func TestGetPeerComInfo(t *testing.T) {
 		}
 	}
 
-	if p.base.GetRelay() != true {
+	if !p.base.GetRelay() {
 		t.Errorf("PeerCom GetRelay error")
 	} else {
 		p.base.SetRelay(false)
-		if p.base.GetRelay() != false {
+		if p.base.GetRelay() {
 			t.Errorf("PeerCom SetRelay error")
 		}
 	}


### PR DESCRIPTION
1. code as below can be written just one line: `return xxx == yyy`
```
if xxx == yyy {
    return true
}
return false
```
2. there's no need to compare bool to true or false, just use their own value is enough.