### PR TITLE
Change break to return

### DIFF
--- a/main.go
+++ b/main.go
@@ -417,6 +417,7 @@ func initNodeInfo(ctx *cli.Context, p2pSvr *p2pserver.P2PServer) {
 
 func logCurrBlockHeight() {
 	ticker := time.NewTicker(config.DEFAULT_GEN_BLOCK_TIME * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:

--- a/p2pserver/block_sync.go
+++ b/p2pserver/block_sync.go
@@ -326,6 +326,7 @@ func (this *BlockSyncMgr) getNonEmptyBlockCount() int {
 func (this *BlockSyncMgr) Start() {
 	go this.sync()
 	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-this.exitCh:

--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -454,7 +454,7 @@ func (this *P2PServer) connectSeedService() {
 			}
 		case <-this.quitOnline:
 			t.Stop()
-			break
+			return
 		}
 	}
 }
@@ -470,7 +470,7 @@ func (this *P2PServer) keepOnlineService() {
 			t.Reset(time.Second * common.CONN_MONITOR)
 		case <-this.quitOnline:
 			t.Stop()
-			break
+			return
 		}
 	}
 }
@@ -593,7 +593,7 @@ func (this *P2PServer) syncUpRecentPeers() {
 			this.syncPeerAddr()
 		case <-this.quitSyncRecent:
 			t.Stop()
-			break
+			return
 		}
 	}
 


### PR DESCRIPTION
1. Just like PR1106, break does not break the for loop
    A "break" statement terminates execution of the innermost "for", "switch", or "select" statement within the same function.[1]
2. some time.Ticker have not call Stop() before quit.

[1]. https://golang.org/ref/spec#Break_statements