### PR TITLE
Add some small improvement

### DIFF
--- a/main.go
+++ b/main.go
@@ -344,23 +344,23 @@ func initRpc(ctx *cli.Context) error {
 		return nil
 	}
 	var err error
-	exitCh := make(chan interface{}, 0)
+	exitCh := make(chan struct{}, 0)
 	go func() {
 		err = jsonrpc.StartRPCServer()
 		close(exitCh)
 	}()
 
-	flag := false
+	// StartRPCServer will call http.ListenAndServe
+	// so when return immediately means it does not start OK
+	// regist 30 handler and call http.ListenAndServe consume
+	// 150us approximately, 5ms here is enough
 	select {
 	case <-exitCh:
-		if !flag {
-			return err
-		}
+		return err
 	case <-time.After(time.Millisecond * 5):
-		flag = true
+		log.Infof("Rpc init success")
+		return nil
 	}
-	log.Infof("Rpc init success")
-	return nil
 }
 
 func initLocalRpc(ctx *cli.Context) error {
@@ -368,24 +368,23 @@ func initLocalRpc(ctx *cli.Context) error {
 		return nil
 	}
 	var err error
-	exitCh := make(chan interface{}, 0)
+	exitCh := make(chan struct{}, 0)
 	go func() {
 		err = localrpc.StartLocalServer()
 		close(exitCh)
 	}()
 
-	flag := false
+	// StartLocalServer will call http.ListenAndServe
+	// so when return immediately means it does not start OK
+	// regist 30 handler and call http.ListenAndServe consume
+	// 150us approximately, 5ms here is enough
 	select {
 	case <-exitCh:
-		if !flag {
-			return err
-		}
+		return err
 	case <-time.After(time.Millisecond * 5):
-		flag = true
+		log.Infof("Local rpc init success")
+		return nil
 	}
-
-	log.Infof("Local rpc init success")
-	return nil
 }
 
 func initRestful(ctx *cli.Context) {

--- a/p2pserver/message/types/message_test.go
+++ b/p2pserver/message/types/message_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"io"
 	"testing"
-	"time"
 
 	common2 "github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/p2pserver/common"
@@ -66,22 +65,21 @@ func TestMsgHdr2(t *testing.T) {
 	}
 }
 
-func TestMsgHdrDesPerformance(t *testing.T) {
+func BenchmarkHdrDesPerformanceSink(b *testing.B) {
 	hdr := newMessageHeader("hdrtest2", 20, common.Checksum([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	sink := common2.NewZeroCopySink(nil)
+	writeMessageHeaderInto(sink, hdr)
+	for i := 0; i < b.N; i++ {
+		readMessageHeader(bytes.NewBuffer(sink.Bytes()))
+	}
+}
 
+func BenchmarkHdrDesPerformanceOld(b *testing.B) {
+	hdr := newMessageHeader("hdrtest2", 20, common.Checksum([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
 	sink := common2.NewZeroCopySink(nil)
 	writeMessageHeaderInto(sink, hdr)
 
-	cnt := 1000000
-	startTime := time.Now()
-	for i := 0; i < cnt; i++ {
-		readMessageHeader(bytes.NewBuffer(sink.Bytes()))
-	}
-	t.Logf("hdr1: time: %v", time.Since(startTime))
-
-	startTime = time.Now()
-	for i := 0; i < cnt; i++ {
+	for i := 0; i < b.N; i++ {
 		readMessageHeader_old(bytes.NewBuffer(sink.Bytes()))
 	}
-	t.Logf("hdr1: time: %v", time.Since(startTime))
 }

--- a/p2pserver/message/types/message_test.go
+++ b/p2pserver/message/types/message_test.go
@@ -60,7 +60,7 @@ func TestMsgHdr2(t *testing.T) {
 	if hdr1.Length != hdr.Length ||
 		hdr1.Magic != hdr.Magic ||
 		hdr1.CMD != hdr.CMD ||
-		hdr1.Checksum != hdr1.Checksum {
+		hdr1.Checksum != hdr.Checksum {
 		t.Fatalf("invalid hdr1: %v", hdr1)
 	}
 }

--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -540,9 +540,7 @@ func (this *P2PServer) addToRetryList(addr string) {
 	if this.RetryAddrs == nil {
 		this.RetryAddrs = make(map[string]int)
 	}
-	if _, ok := this.RetryAddrs[addr]; ok {
-		delete(this.RetryAddrs, addr)
-	}
+	delete(this.RetryAddrs, addr)
 	//alway set retry to 0
 	this.RetryAddrs[addr] = 0
 }
@@ -552,9 +550,7 @@ func (this *P2PServer) removeFromRetryList(addr string) {
 	this.ReconnectAddrs.Lock()
 	defer this.ReconnectAddrs.Unlock()
 	if len(this.RetryAddrs) > 0 {
-		if _, ok := this.RetryAddrs[addr]; ok {
-			delete(this.RetryAddrs, addr)
-		}
+		delete(this.RetryAddrs, addr)
 	}
 }
 

--- a/p2pserver/p2pserver.go
+++ b/p2pserver/p2pserver.go
@@ -605,7 +605,7 @@ func (this *P2PServer) syncPeerAddr() {
 	netID := config.DefConfig.P2PNode.NetworkMagic
 	for i := 0; i < len(this.recentPeers[netID]); i++ {
 		p := this.network.GetPeerFromAddr(this.recentPeers[netID][i])
-		if p == nil || (p != nil && p.GetState() != common.ESTABLISH) {
+		if p == nil || p.GetState() != common.ESTABLISH {
 			this.recentPeers[netID] = append(this.recentPeers[netID][:i], this.recentPeers[netID][i+1:]...)
 			changed = true
 			i--

--- a/p2pserver/peer/nbr_peer_test.go
+++ b/p2pserver/peer/nbr_peer_test.go
@@ -20,10 +20,11 @@ package peer
 
 import (
 	"fmt"
-	p2pcomm "github.com/ontio/ontology/p2pserver/common"
 	"os"
 	"testing"
 	"time"
+
+	p2pcomm "github.com/ontio/ontology/p2pserver/common"
 )
 
 var (
@@ -72,10 +73,10 @@ func initTestNbrPeers() *NbrPeers {
 
 func TestNodeExisted(t *testing.T) {
 	if !nm.nodeExisted(startID) {
-		t.Fatal("0x7533345 should in nbr peers")
+		t.Fatalf("%d should in nbr peers", startID)
 	}
 	if nm.nodeExisted(startID - 1) {
-		t.Fatal("0x5533345 should not in nbr peers")
+		t.Fatalf("%d should not in nbr peers", startID-1)
 	}
 }
 
@@ -94,11 +95,12 @@ func TestAddAndDelNbrNode(t *testing.T) {
 	p.SetState(p2pcomm.HAND_SHAKE)
 	p.SetHttpInfoState(true)
 	p.Link.SetAddr("127.0.0.1")
+	orignLen := len(nm.List)
 	nm.AddNbrNode(p)
 	if !nm.nodeExisted(newID) {
-		t.Fatal("0x7123456 should be added in nbr peer")
+		t.Fatalf("%d should be added in nbr peer", newID)
 	}
-	if len(nm.List) != 6 {
+	if len(nm.List) != orignLen+1 {
 		t.Fatal("0x7123456 should be added in nbr peer")
 	}
 

--- a/p2pserver/peer/nbr_peers.go
+++ b/p2pserver/peer/nbr_peers.go
@@ -47,8 +47,8 @@ func (this *NbrPeers) Broadcast(msg types.Message) {
 	}
 }
 
-//NodeExisted return when peer in nbr list
-func (this *NbrPeers) NodeExisted(uid uint64) bool {
+//nodeExisted return when peer in nbr list
+func (this *NbrPeers) nodeExisted(uid uint64) bool {
 	_, ok := this.List[uid]
 	return ok
 }
@@ -69,7 +69,7 @@ func (this *NbrPeers) AddNbrNode(p *Peer) {
 	this.Lock()
 	defer this.Unlock()
 
-	if this.NodeExisted(p.GetID()) {
+	if this.nodeExisted(p.GetID()) {
 		fmt.Printf("[p2p]insert an existed node\n")
 	} else {
 		this.List[p.GetID()] = p


### PR DESCRIPTION
1. in main.go:initRpc()/initLocalRpc() flag is useless

```
	flag := false
	select {
	case <-exitCh:
		if !flag {
			return err
		}
	case <-time.After(time.Millisecond * 5):
		flag = true
	}
```

  select is a one time statement. if select
  + goes to the first case, flag is definitely false, so the check is redundant. 
  + goes to the second case, flag is not used after the setting. 
so there's no need to add this flag variable.
2. some inner function should not be exported: NbrPeers::NodeExisted
3. ` if p == nil || (p != nil && p.GetState() != common.ESTABLISH)`  when the or statement goes to the second part it means the first part is already evaluated to false, in this case it means p == nil evaluated to false so p is not nil. so the second part p != nil is included implicitly. Drop this check in second part.
4. change some benchmark test to golang Benchmark testing
5. imrove nbrpeers test case.
6. typo in test
7. unnecessary guard around call to delete, Deleting a non-existent entry in map is a no-op.