### PR TITLE
replace go-interpreter/wagon to ontio/wagon

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -40,8 +40,7 @@ import:
   - unix
 - package: golang.org/x/net
   repo: https://github.com/golang/net.git
-- package: github.com/go-interpreter/wagon
-  repo: https://github.com/ontio/wagon.git
-  version: db6073fb277612b196eac4f10fa8ca787b292f96
+- package: github.com/ontio/wagon
+  version: v0.4.1
 ignore:
   - golang.org/x/sys/unix

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/ethereum/go-ethereum v1.9.6
-	github.com/go-interpreter/wagon v0.6.0
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/gorilla/websocket v1.4.1
 	github.com/gosuri/uilive v0.0.3 // indirect
@@ -18,6 +17,7 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/ontio/ontology-crypto v1.0.5
 	github.com/ontio/ontology-eventbus v0.9.1
+	github.com/ontio/wagon v0.4.1
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/stretchr/testify v1.3.0
@@ -29,7 +29,6 @@ require (
 )
 
 replace (
-	github.com/go-interpreter/wagon => github.com/ontio/wagon v0.3.1-0.20191223040208-db6073fb2776
 	golang.org/x/crypto => github.com/golang/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/net => github.com/golang/net v0.0.0-20191028085509-fe3aa8a45271
 	golang.org/x/sys => github.com/golang/sys v0.0.0-20190412213103-97732733099d

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,10 @@ github.com/ontio/ontology-crypto v1.0.5 h1:VYIEL9yF1d8vWxgLedqoQXKdyw2oY46NliGCQ
 github.com/ontio/ontology-crypto v1.0.5/go.mod h1:ebrQJ4/VS2F6pwHGktHDYtY/7Y2ca/ogfnlYABrQI2c=
 github.com/ontio/ontology-eventbus v0.9.1 h1:nt3AXWx3gOyqtLiU4EwI92Yc4ik/pWHu9xRK15uHSOs=
 github.com/ontio/ontology-eventbus v0.9.1/go.mod h1:hCQIlbdPckcfykMeVUdWrqHZ8d30TBdmLfXCVWGkYhM=
-github.com/ontio/wagon v0.3.1-0.20191223040208-db6073fb2776 h1:cfHznrh9WsSH7F253Lr6TkYa38p/3Cgk0PJS7238cRQ=
-github.com/ontio/wagon v0.3.1-0.20191223040208-db6073fb2776/go.mod h1:zHOMvbitcZek8oshsMO5VpyBjWjV9X8cn8WTZwdebpM=
+github.com/ontio/wagon v0.4.0 h1:0v0VOtcrh/vZWiXSyc5pS2FpoiD8OwExack/LthjyqI=
+github.com/ontio/wagon v0.4.0/go.mod h1:oTPdgWT7WfPlEyzVaHSn1vQPMSbOpQPv+WphxibWlhg=
+github.com/ontio/wagon v0.4.1 h1:3A8BxTMVGrQnyWxD1h8w5PLvN9GZMWjC75Jw+5Vgpe0=
+github.com/ontio/wagon v0.4.1/go.mod h1:oTPdgWT7WfPlEyzVaHSn1vQPMSbOpQPv+WphxibWlhg=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,6 @@ github.com/ontio/ontology-crypto v1.0.5 h1:VYIEL9yF1d8vWxgLedqoQXKdyw2oY46NliGCQ
 github.com/ontio/ontology-crypto v1.0.5/go.mod h1:ebrQJ4/VS2F6pwHGktHDYtY/7Y2ca/ogfnlYABrQI2c=
 github.com/ontio/ontology-eventbus v0.9.1 h1:nt3AXWx3gOyqtLiU4EwI92Yc4ik/pWHu9xRK15uHSOs=
 github.com/ontio/ontology-eventbus v0.9.1/go.mod h1:hCQIlbdPckcfykMeVUdWrqHZ8d30TBdmLfXCVWGkYhM=
-github.com/ontio/wagon v0.4.0 h1:0v0VOtcrh/vZWiXSyc5pS2FpoiD8OwExack/LthjyqI=
-github.com/ontio/wagon v0.4.0/go.mod h1:oTPdgWT7WfPlEyzVaHSn1vQPMSbOpQPv+WphxibWlhg=
 github.com/ontio/wagon v0.4.1 h1:3A8BxTMVGrQnyWxD1h8w5PLvN9GZMWjC75Jw+5Vgpe0=
 github.com/ontio/wagon v0.4.1/go.mod h1:oTPdgWT7WfPlEyzVaHSn1vQPMSbOpQPv+WphxibWlhg=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=

--- a/smartcontract/service/wasmvm/block.go
+++ b/smartcontract/service/wasmvm/block.go
@@ -18,7 +18,7 @@
 package wasmvm
 
 import (
-	"github.com/go-interpreter/wagon/exec"
+	"github.com/ontio/wagon/exec"
 )
 
 func GetCurrentBlockHash(proc *exec.Process, ptr uint32) uint32 {

--- a/smartcontract/service/wasmvm/contract.go
+++ b/smartcontract/service/wasmvm/contract.go
@@ -19,7 +19,7 @@
 package wasmvm
 
 import (
-	"github.com/go-interpreter/wagon/exec"
+	"github.com/ontio/wagon/exec"
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/core/payload"
 	"github.com/ontio/ontology/errors"

--- a/smartcontract/service/wasmvm/contract.go
+++ b/smartcontract/service/wasmvm/contract.go
@@ -19,10 +19,10 @@
 package wasmvm
 
 import (
-	"github.com/ontio/wagon/exec"
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/core/payload"
 	"github.com/ontio/ontology/errors"
+	"github.com/ontio/wagon/exec"
 )
 
 func ContractCreate(proc *exec.Process,

--- a/smartcontract/service/wasmvm/runtime.go
+++ b/smartcontract/service/wasmvm/runtime.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/go-interpreter/wagon/exec"
-	"github.com/go-interpreter/wagon/wasm"
+	"github.com/ontio/wagon/exec"
+	"github.com/ontio/wagon/wasm"
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/common/log"
 	"github.com/ontio/ontology/core/payload"

--- a/smartcontract/service/wasmvm/runtime.go
+++ b/smartcontract/service/wasmvm/runtime.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ontio/wagon/exec"
-	"github.com/ontio/wagon/wasm"
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/common/log"
 	"github.com/ontio/ontology/core/payload"
@@ -37,6 +35,8 @@ import (
 	"github.com/ontio/ontology/smartcontract/states"
 	"github.com/ontio/ontology/vm/crossvm_codec"
 	neotypes "github.com/ontio/ontology/vm/neovm/types"
+	"github.com/ontio/wagon/exec"
+	"github.com/ontio/wagon/wasm"
 	"io"
 )
 

--- a/smartcontract/service/wasmvm/storage.go
+++ b/smartcontract/service/wasmvm/storage.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"math"
 
-	"github.com/go-interpreter/wagon/exec"
+	"github.com/ontio/wagon/exec"
 	"github.com/ontio/ontology/core/states"
 )
 

--- a/smartcontract/service/wasmvm/storage.go
+++ b/smartcontract/service/wasmvm/storage.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 	"math"
 
-	"github.com/ontio/wagon/exec"
 	"github.com/ontio/ontology/core/states"
+	"github.com/ontio/wagon/exec"
 )
 
 func StorageRead(proc *exec.Process, keyPtr uint32, klen uint32, val uint32, vlen uint32, offset uint32) uint32 {

--- a/smartcontract/service/wasmvm/utils.go
+++ b/smartcontract/service/wasmvm/utils.go
@@ -22,9 +22,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-interpreter/wagon/exec"
-	"github.com/go-interpreter/wagon/validate"
-	"github.com/go-interpreter/wagon/wasm"
+	"github.com/ontio/wagon/exec"
+	"github.com/ontio/wagon/validate"
+	"github.com/ontio/wagon/wasm"
 )
 
 func ReadWasmMemory(proc *exec.Process, ptr uint32, len uint32) ([]byte, error) {

--- a/smartcontract/service/wasmvm/wasm_service.go
+++ b/smartcontract/service/wasmvm/wasm_service.go
@@ -18,7 +18,6 @@
 package wasmvm
 
 import (
-	"github.com/ontio/wagon/exec"
 	"github.com/hashicorp/golang-lru"
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/core/store"
@@ -28,6 +27,7 @@ import (
 	"github.com/ontio/ontology/smartcontract/event"
 	"github.com/ontio/ontology/smartcontract/states"
 	"github.com/ontio/ontology/smartcontract/storage"
+	"github.com/ontio/wagon/exec"
 )
 
 type WasmVmService struct {

--- a/smartcontract/service/wasmvm/wasm_service.go
+++ b/smartcontract/service/wasmvm/wasm_service.go
@@ -18,7 +18,7 @@
 package wasmvm
 
 import (
-	"github.com/go-interpreter/wagon/exec"
+	"github.com/ontio/wagon/exec"
 	"github.com/hashicorp/golang-lru"
 	"github.com/ontio/ontology/common"
 	"github.com/ontio/ontology/core/store"

--- a/wasmtest/wasm-test.go
+++ b/wasmtest/wasm-test.go
@@ -31,8 +31,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ontio/wagon/exec"
-	"github.com/ontio/wagon/wasm"
 	"github.com/ontio/ontology-crypto/keypair"
 	"github.com/ontio/ontology/account"
 	"github.com/ontio/ontology/cmd/utils"
@@ -52,6 +50,8 @@ import (
 	"github.com/ontio/ontology/smartcontract/states"
 	vmtypes "github.com/ontio/ontology/vm/neovm/types"
 	common3 "github.com/ontio/ontology/wasmtest/common"
+	"github.com/ontio/wagon/exec"
+	"github.com/ontio/wagon/wasm"
 )
 
 const contractDir = "testwasmdata"

--- a/wasmtest/wasm-test.go
+++ b/wasmtest/wasm-test.go
@@ -31,8 +31,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-interpreter/wagon/exec"
-	"github.com/go-interpreter/wagon/wasm"
+	"github.com/ontio/wagon/exec"
+	"github.com/ontio/wagon/wasm"
 	"github.com/ontio/ontology-crypto/keypair"
 	"github.com/ontio/ontology/account"
 	"github.com/ontio/ontology/cmd/utils"


### PR DESCRIPTION
to fix the limitation of `replace` in  go mod.