### PR TITLE
check peer existence before reconnecting.

### DIFF
--- a/p2pserver/protocols/bootstrap/bootstrap.go
+++ b/p2pserver/protocols/bootstrap/bootstrap.go
@@ -20,7 +20,6 @@ package bootstrap
 import (
 	"math/rand"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/ontio/ontology/common/log"
@@ -109,10 +108,8 @@ func (self *BootstrapService) connectSeeds() {
 	connPeers := make(map[string]*peer.Peer)
 	nps := self.net.GetNeighbors()
 	for _, tn := range nps {
-		ipAddr, _ := tn.GetAddr16()
-		ip := net.IP(ipAddr[:])
-		addrString := ip.To16().String() + ":" + strconv.Itoa(int(tn.GetPort()))
-		connPeers[addrString] = tn
+		listenAddr := tn.Info.RemoteListenAddress()
+		connPeers[listenAddr] = tn
 	}
 
 	seedConnList := make([]*peer.Peer, 0)

--- a/p2pserver/protocols/reconnect/reconnect.go
+++ b/p2pserver/protocols/reconnect/reconnect.go
@@ -19,9 +19,7 @@
 package reconnect
 
 import (
-	"fmt"
 	"math/rand"
-	"strconv"
 	"sync"
 	"time"
 
@@ -32,11 +30,16 @@ import (
 	"github.com/ontio/ontology/p2pserver/peer"
 )
 
+type Info struct {
+	count int
+	id    common.PeerId
+}
+
 //ReconnectService contain addr need to reconnect
 type ReconnectService struct {
 	sync.RWMutex
 	MaxRetryCount uint
-	RetryAddrs    map[string]int
+	RetryAddrs    map[string]Info
 	net           p2p.P2P
 	quit          chan bool
 }
@@ -46,7 +49,7 @@ func NewReconectService(net p2p.P2P) *ReconnectService {
 		net:           net,
 		MaxRetryCount: common.MAX_RETRY_COUNT,
 		quit:          make(chan bool),
-		RetryAddrs:    make(map[string]int),
+		RetryAddrs:    make(map[string]Info),
 	}
 }
 
@@ -71,34 +74,17 @@ func (this *ReconnectService) keepOnlineService() {
 	}
 }
 
-func getPeerListenAddr(p *peer.PeerInfo) (string, error) {
-	addrIp, err := common.ParseIPAddr(p.Addr)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse addr: %s", p.Addr)
-	}
-	nodeAddr := addrIp + ":" + strconv.Itoa(int(p.Port))
-	return nodeAddr, nil
-}
-
 func (self *ReconnectService) OnAddPeer(p *peer.PeerInfo) {
-	nodeAddr, err := getPeerListenAddr(p)
-	if err != nil {
-		log.Errorf("failed to parse addr: %s", p.Addr)
-		return
-	}
+	listenAddr := p.RemoteListenAddress()
 	self.Lock()
-	delete(self.RetryAddrs, nodeAddr)
+	delete(self.RetryAddrs, listenAddr)
 	self.Unlock()
 }
 
 func (self *ReconnectService) OnDelPeer(p *peer.PeerInfo) {
-	nodeAddr, err := getPeerListenAddr(p)
-	if err != nil {
-		log.Errorf("failed to parse addr: %s", p.Addr)
-		return
-	}
+	nodeAddr := p.RemoteListenAddress()
 	self.Lock()
-	self.RetryAddrs[nodeAddr] = 0
+	self.RetryAddrs[nodeAddr] = Info{count: 0, id: p.Id}
 	self.Unlock()
 }
 
@@ -115,12 +101,12 @@ func (this *ReconnectService) retryInactivePeer() {
 	if len(this.RetryAddrs) > 0 {
 		this.Lock()
 
-		list := make(map[string]int)
+		list := make(map[string]Info)
 		addrs := make([]string, 0, len(this.RetryAddrs))
 		for addr, v := range this.RetryAddrs {
-			v += 1
-			addrs = append(addrs, addr)
-			if v < common.MAX_RETRY_COUNT {
+			v.count += 1
+			if v.count <= common.MAX_RETRY_COUNT && net.GetPeer(v.id) == nil {
+				addrs = append(addrs, addr)
 				list[addr] = v
 			}
 		}


### PR DESCRIPTION
when two nodes established 2 connection, the first one will be closed.
but the address will be added in reconnect list, and the reconnect rely
on NodeConnect system message to remove the node. so it will never be removed,
since the NodeConnect message of the second connection has already been dispatched.