### PR TITLE
change rpc id type from int64 to interface{}

### DIFF
--- a/http/base/rpc/rpc.go
+++ b/http/base/rpc/rpc.go
@@ -43,7 +43,7 @@ type JReq struct {
 	JSONRPC string        `json:"jsonrpc"`
 	Method  string        `json:"method"`
 	Params  []interface{} `json:"params"`
-	ID      int64         `json:"id"`
+	ID      interface{}   `json:"id"`
 }
 
 func init() {


### PR DESCRIPTION
JSON RPC 2.0: An identifier established by the Client that MUST contain a String, Number, or NULL value if included.