### PR TITLE
update log PATH when init log

### DIFF
--- a/common/log/log.go
+++ b/common/log/log.go
@@ -364,6 +364,7 @@ func createLog(logLevel int, a ...interface{}) *Logger {
 					os.Exit(1)
 				}
 				writers = append(writers, logFile)
+				PATH = o.(string)
 			case *os.File:
 				writers = append(writers, o.(*os.File))
 			default:


### PR DESCRIPTION
Log system always use PATH variable to create new log file. If log-dir that user specified is  not same with PATH default value, the new log file would be created to PATH, not user specified log-dir.