### PR TITLE
Fix typos across multiple files

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -36,7 +36,7 @@ import (
 type Client interface {
 	//NewAccount create a new account.
 	NewAccount(label string, typeCode keypair.KeyType, curveCode byte, sigScheme s.SignatureScheme, passwd []byte) (*Account, error)
-	//ImportAccount import a already exist account to wallet
+	//ImportAccount import an already exist account to wallet
 	ImportAccount(accMeta *AccountMetadata) error
 	//GetAccountByAddress return account object by address
 	GetAccountByAddress(address string, passwd []byte) (*Account, error)

--- a/cmd/utils/native_param.go
+++ b/cmd/utils/native_param.go
@@ -244,7 +244,7 @@ func ParseNativeParamAddress(builder *neovm.ParamsBuilder, param string) error {
 	//Maybe param is a contract address
 	addr, err = common.AddressFromHexString(param)
 	if err != nil {
-		//Maybe param is a account address
+		//Maybe param is an account address
 		addr, err = common.AddressFromBase58(param)
 		if err != nil {
 			return fmt.Errorf("invalid address")

--- a/common/zero_copy_sink.go
+++ b/common/zero_copy_sink.go
@@ -27,7 +27,7 @@ type ZeroCopySink struct {
 	buf []byte
 }
 
-// tryGrowByReslice is a inlineable version of grow for the fast-case where the
+// tryGrowByReslice is an inlineable version of grow for the fast-case where the
 // internal buffer only needs to be resliced.
 // It returns the index where bytes should be written and whether it succeeded.
 func (self *ZeroCopySink) tryGrowByReslice(n int) (int, bool) {

--- a/core/store/ledgerstore/state_store.go
+++ b/core/store/ledgerstore/state_store.go
@@ -132,13 +132,13 @@ func (self *StateStore) init(currBlockHeight uint32) error {
 	return nil
 }
 
-//GetStateMerkleTree return merkle tree size an tree node
+//GetStateMerkleTree return merkle tree size a tree node
 func (self *StateStore) GetStateMerkleTree() (uint32, []common.Uint256, error) {
 	key := self.genStateMerkleTreeKey()
 	return self.getMerkleTree(key)
 }
 
-//GetBlockMerkleTree return merkle tree size an tree node
+//GetBlockMerkleTree return merkle tree size a tree node
 func (self *StateStore) GetBlockMerkleTree() (uint32, []common.Uint256, error) {
 	key := self.genBlockMerkleTreeKey()
 	return self.getMerkleTree(key)

--- a/p2pserver/dht/kbucket/table.go
+++ b/p2pserver/dht/kbucket/table.go
@@ -196,7 +196,7 @@ func (rt *RouteTable) nextBucket() {
 	newBucket := bucket.Split(len(rt.Buckets)-1, rt.local)
 	rt.Buckets = append(rt.Buckets, newBucket)
 
-	// The newly formed bucket still contains too many peers. We probably just unfolded a empty bucket.
+	// The newly formed bucket still contains too many peers. We probably just unfolded an empty bucket.
 	if newBucket.Len() >= rt.bucketsize {
 		// Keep unfolding the table until the last bucket is not overflowing.
 		rt.nextBucket()

--- a/p2pserver/net/protocol/server.go
+++ b/p2pserver/net/protocol/server.go
@@ -16,7 +16,7 @@
  * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Package p2p provides an network interface
+// Package p2p provides a network interface
 package p2p
 
 import (


### PR DESCRIPTION
This PR fixes minor typos in comments and documentation across several files in the codebase to improve clarity and grammatical accuracy.

---

### Files Updated  
1. **account/client.go**  
   - Fixed "import a already exist account" to "import an already exist account."

2. **cmd/utils/native_param.go**  
   - Corrected "param is a account address" to "param is an account address."

3. **common/zero_copy_sink.go**  
   - Changed "is a inlineable version" to "is an inlineable version."

4. **core/store/ledgerstore/state_store.go**  
   - Updated "return merkle tree size an tree node" to "return merkle tree size a tree node."

5. **p2pserver/dht/kbucket/table.go**  
   - Corrected "unfolded a empty bucket" to "unfolded an empty bucket."

6. **p2pserver/net/protocol/server.go**  
   - Fixed "provides an network interface" to "provides a network interface."

---

### Notes for Reviewers  
Please review the changes to ensure consistency with the intended meaning of the comments and documentation.

---

### Signed Commits  
- [x] Yes, I signed my commits.
